### PR TITLE
Added ROS 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,70 @@ The goal of this project is to create a pluginlib-based C++ library that can int
 
 # Installation
 
-This package is developed and on Ubuntu 22.04 LTS with ROS 2 Humble.
+This package is developed and on Ubuntu 22.04 LTS with ROS 2 Humble. We suggest installing ROS 2 Humble from binary packages, and building Gazebo Garden from source. The following steps will describe this process, resulting in two workspaces: one for Gazebo Garden, and an overlaid workspace for the Vehicle Gateway (this project), in order to make rebuilds faster.
 
-If you have installed ROS 2 Humble from APT on your system (the recommended method unless you prefer to work from source), the following steps will create a workspace for this repo and build it:
+To keep paths short, `vg` stands for "Vehicle Gateway". After these steps, you'll have two workspaces in the `~/vg` directory, like this:
 
-First, install ROS 2 and Gazebo Garden.
-Note that Gazebo Garden must be installed separately, following its instructions below; it is not the version that ships with Ubuntu 22.04 LTS.
-This is why `ros_gz` must be built as part of the repository dependencies in subsequent steps.
- * [ROS 2 Humble binary installation instructure](http://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html)
- * [Gazebo Garden binary installation instructions](https://gazebosim.org/docs/garden/install_ubuntu)
+```
+vg
+├── gz_ws
+│   ├── build
+│   ├── install
+│   ├── log
+│   └── src
+└── vg_ws
+    ├── build
+    ├── install
+    ├── log
+    └── src
+```
 
+First, install ROS 2 Humble using the `.deb` packages using APT [according to these instructions](http://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html)
+
+Next, install a few dependencies and set up our workspace source directories:
 ```bash
 sudo apt install python3-kconfiglib python3-jinja2 python3-jsonschema ros-humble-gps-msgs
 pip3 install pyros-genmsg
-mkdir -p ~/vg_ws/src
-cd ~/vg_ws/src
+mkdir -p ~/vg/vg_ws/src
+cd ~/vg/vg_ws/src
 git clone https://github.com/osrf/vehicle_gateway
-cd ~/vg_ws
+cd ~/vg/vg_ws
 vcs import src < src/vehicle_gateway/dependencies.repos
-rosdep update && rosdep install --from-paths src --ignore-src -y
+```
+
+Next, build Gazebo Garden from source. The full instructions are [here](https://gazebosim.org/docs/garden/install_ubuntu_src), and summarized in the following command sequence:
+
+```bash
+mkdir -p ~/vg/gz_ws/src
+cd ~/vg/gz_ws
+vcs import src < ../vg_ws/src/vehicle_gateway/gazebo.repos
+sudo apt install -y $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/gz\|sdf/d' | tr '\n' ' ')
 source /opt/ros/humble/setup.bash
+colcon build --merge-install
+```
+Now you should have Gazebo available to any terminals that source `~/vg/gz_ws/install/setup.bash`
+
+We can now build the Vehicle Gateway itself, by overlaying its workspace on top of the Gazebo Garden workspace (which in turn is overlaying the ROS 2 Humble system installation). The Vehicle Gateway build will also download and build the PX4 firmware, to allow software-in-the-loop (SITL) simulation:
+
+```bash
+cd ~/vg/vg_ws
+rosdep update && rosdep install --from-paths src --ignore-src -y
+source ~/vg/gz_ws/install/setup.bash
 colcon build --event-handlers console_direct+
+```
+
+As a last step, we will build the Micro-ROS agent in this workspace
+
+```bash
+cd ~/vg/vg_ws
 source install/setup.bash
 ros2 run micro_ros_setup create_agent_ws.sh
 ros2 run micro_ros_setup build_agent.sh
+```
+
+# Run a PX4 Quadcopter demo
+```bash
+cd ~/vg/vg_ws
+source install/setup.bash
+ros2 launch px4_sim x500_launch.py
 ```

--- a/README.md
+++ b/README.md
@@ -14,14 +14,18 @@ This is why `ros_gz` must be built as part of the repository dependencies in sub
  * [ROS 2 Humble binary installation instructure](http://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html)
  * [Gazebo Garden binary installation instructions](https://gazebosim.org/docs/garden/install_ubuntu)
 
-```
+```bash
 sudo apt install python3-kconfiglib python3-jinja2 python3-jsonschema ros-humble-gps-msgs
 pip3 install pyros-genmsg
 mkdir -p ~/vg_ws/src
 cd ~/vg_ws/src
 git clone https://github.com/osrf/vehicle_gateway
-vcs import src < src/vehicle_gateway/dependencies.repos
 cd ~/vg_ws
+vcs import src < src/vehicle_gateway/dependencies.repos
+rosdep update && rosdep install --from-paths src --ignore-src -y
 source /opt/ros/humble/setup.bash
-colcon build
+colcon build --event-handlers console_direct+
+source install/setup.bash
+ros2 run micro_ros_setup create_agent_ws.sh
+ros2 run micro_ros_setup build_agent.sh
 ```

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: https://github.com/gazebosim/gz-msgs
     version: ahcorde/air_speed
+  micro-ros/micro_ros_setup:
+    type: git
+    url: https://github.com/micro-ROS/micro_ros_setup
+    version: humble

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -23,3 +23,7 @@ repositories:
     type: git
     url: https://github.com/micro-ROS/micro_ros_setup
     version: humble
+  px4_msgs:
+    type: git
+    url: https://github.com/PX4/px4_msgs
+    version: main

--- a/px4_sim/launch/plane.launch.py
+++ b/px4_sim/launch/plane.launch.py
@@ -17,6 +17,7 @@ from distutils.dir_util import copy_tree
 import launch
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch_ros.actions import Node
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 import tempfile
 import os
@@ -66,6 +67,12 @@ def generate_launch_description():
 
     world_sdf = os.path.join(get_px4_dir(), "worlds", "empty_px4_world.sdf")
 
+    micro_ros_agent = Node(
+        package='micro_ros_agent',
+        executable='micro_ros_agent',
+        arguments=["udp4", "-p", "8888"],
+        output='screen')
+
     return LaunchDescription([
         # Launch gazebo environment
         IncludeLaunchDescription(
@@ -75,5 +82,6 @@ def generate_launch_description():
           launch_arguments=[('gz_args', [' -r -v 4 ' + world_sdf])]),
         run_px4,
         use_sim_time_arg,
-        ExecuteProcess(cmd=['QGroundControl.AppImage'])
+        ExecuteProcess(cmd=['QGroundControl.AppImage']),
+        micro_ros_agent
     ])

--- a/px4_sim/launch/standard_vtol.launch.py
+++ b/px4_sim/launch/standard_vtol.launch.py
@@ -17,6 +17,7 @@ from distutils.dir_util import copy_tree
 import launch
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch_ros.actions import Node
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 import tempfile
 import os
@@ -68,6 +69,12 @@ def generate_launch_description():
 
     world_sdf = os.path.join(get_px4_dir(), "worlds", "empty_px4_world.sdf")
 
+    micro_ros_agent = Node(
+        package='micro_ros_agent',
+        executable='micro_ros_agent',
+        arguments=["udp4", "-p", "8888"],
+        output='screen')
+
     return LaunchDescription([
         # Launch gazebo environment
         IncludeLaunchDescription(
@@ -77,5 +84,6 @@ def generate_launch_description():
           launch_arguments=[('gz_args', [' -r -v 4 ' + world_sdf])]),
         run_px4,
         use_sim_time_arg,
-        ExecuteProcess(cmd=['QGroundControl.AppImage'])
+        ExecuteProcess(cmd=['QGroundControl.AppImage']),
+        micro_ros_agent
     ])

--- a/px4_sim/launch/x500_launch.py
+++ b/px4_sim/launch/x500_launch.py
@@ -17,6 +17,7 @@ from distutils.dir_util import copy_tree
 import launch
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch_ros.actions import Node
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 import tempfile
 import os
@@ -66,6 +67,12 @@ def generate_launch_description():
 
     world_sdf = os.path.join(get_px4_dir(), "worlds", "empty_px4_world.sdf")
 
+    micro_ros_agent = Node(
+        package='micro_ros_agent',
+        executable='micro_ros_agent',
+        arguments=["udp4", "-p", "8888"],
+        output='screen')
+
     return LaunchDescription([
         # Launch gazebo environment
         IncludeLaunchDescription(
@@ -75,5 +82,6 @@ def generate_launch_description():
           launch_arguments=[('gz_args', [' -r -v 4 ' + world_sdf])]),
         run_px4,
         use_sim_time_arg,
-        ExecuteProcess(cmd=['QGroundControl.AppImage'])
+        ExecuteProcess(cmd=['QGroundControl.AppImage']),
+        micro_ros_agent
     ])


### PR DESCRIPTION
Signed-off-by: Alejandro Hernández Cordero <ahcorde@gmail.com>

Build on top of https://github.com/osrf/vehicle_gateway/pull/4

This PR adds support for ROS 2. It compile the microXCDR agent and it launches with the launch file.

```bash
ros2 launch px4_sim plane.launch.py
```
In other terminal
```bash
source /opt/ros/humble/setup.bash
ros2 topic list
/fmu/in/obstacle_distance
/fmu/in/offboard_control_mode
/fmu/in/onboard_computer_status
/fmu/in/sensor_optical_flow
/fmu/in/telemetry_status
/fmu/in/trajectory_setpoint
/fmu/in/vehicle_attitude_setpoint
/fmu/in/vehicle_command
/fmu/in/vehicle_mocap_odometry
/fmu/in/vehicle_rates_setpoint
/fmu/in/vehicle_trajectory_bezier
/fmu/in/vehicle_trajectory_waypoint
/fmu/in/vehicle_visual_odometry
/fmu/out/failsafe_flags
/fmu/out/sensor_combined
/fmu/out/timesync_status
/fmu/out/vehicle_attitude
/fmu/out/vehicle_control_mode
/fmu/out/vehicle_gps_position
/fmu/out/vehicle_local_position
/fmu/out/vehicle_odometry
/fmu/out/vehicle_status
/parameter_events
/rosout
```