### PR TITLE
include gazebo.repos file referenced in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ cd ~/vg/vg_ws/src
 git clone https://github.com/osrf/vehicle_gateway
 cd ~/vg/vg_ws
 vcs import src < src/vehicle_gateway/dependencies.repos
+vcs import src < src/vehicle_gateway/gazebo.repos
 ```
 
 Next, build Gazebo Garden from source. The full instructions are [here](https://gazebosim.org/docs/garden/install_ubuntu_src), and summarized in the following command sequence:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package is developed and on Ubuntu 22.04 LTS with ROS 2 Humble. We suggest 
 
 To keep paths short, `vg` stands for "Vehicle Gateway". After these steps, you'll have two workspaces in the `~/vg` directory, like this:
 
-```
+```bash
 vg
 ├── gz_ws
 │   ├── build

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,24 +1,4 @@
 repositories:
-  ros_gz:
-    type: git
-    url: https://github.com/gazebosim/ros_gz
-    version: ros2
-  gazebo/gz-sim:
-    type: git
-    url: https://github.com/gazebosim/gz-sim
-    version: ahcorde/air_speed
-  gazebo/gz-sensors:
-    type: git
-    url: https://github.com/gazebosim/gz-sensors
-    version: ahcorde/air_speed
-  gazebo/sdformat:
-    type: git
-    url: https://github.com/gazebosim/sdformat
-    version: ahcorde/air_speed
-  gazebo/gz-msgs:
-    type: git
-    url: https://github.com/gazebosim/gz-msgs
-    version: ahcorde/air_speed
   uros/micro_ros_msgs:
     type: git
     url: https://github.com/micro-ROS/micro_ros_msgs.git

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,4 +1,8 @@
 repositories:
+  ros_gz:
+    type: git
+    url: https://github.com/gazebosim/ros_gz
+    version: ros2
   uros/micro_ros_msgs:
     type: git
     url: https://github.com/micro-ROS/micro_ros_msgs.git

--- a/gazebo.repos
+++ b/gazebo.repos
@@ -1,0 +1,69 @@
+repositories:
+  ros_gz:
+    type: git
+    url: https://github.com/gazebosim/ros_gz
+    version: ros2
+  gz-sim:
+    type: git
+    url: https://github.com/gazebosim/gz-sim
+    version: ahcorde/air_speed
+  gz-sensors:
+    type: git
+    url: https://github.com/gazebosim/gz-sensors
+    version: ahcorde/air_speed
+  sdformat:
+    type: git
+    url: https://github.com/gazebosim/sdformat
+    version: ahcorde/air_speed
+  gz-msgs:
+    type: git
+    url: https://github.com/gazebosim/gz-msgs
+    version: ahcorde/air_speed
+  gz-cmake:
+    type: git
+    url: https://github.com/gazebosim/gz-cmake
+    version: gz-cmake3
+  gz-common:
+    type: git
+    url: https://github.com/gazebosim/gz-common
+    version: gz-common5
+  gz-fuel-tools:
+    type: git
+    url: https://github.com/gazebosim/gz-fuel-tools
+    version: gz-fuel-tools8
+  gz-gui:
+    type: git
+    url: https://github.com/gazebosim/gz-gui
+    version: gz-gui7
+  gz-launch:
+    type: git
+    url: https://github.com/gazebosim/gz-launch
+    version: gz-launch6
+  gz-math:
+    type: git
+    url: https://github.com/gazebosim/gz-math
+    version: gz-math7
+  gz-physics:
+    type: git
+    url: https://github.com/gazebosim/gz-physics
+    version: gz-physics6
+  gz-plugin:
+    type: git
+    url: https://github.com/gazebosim/gz-plugin
+    version: gz-plugin2
+  gz-rendering:
+    type: git
+    url: https://github.com/gazebosim/gz-rendering
+    version: gz-rendering7
+  gz-tools:
+    type: git
+    url: https://github.com/gazebosim/gz-tools
+    version: gz-tools2
+  gz-transport:
+    type: git
+    url: https://github.com/gazebosim/gz-transport
+    version: gz-transport12
+  gz-utils:
+    type: git
+    url: https://github.com/gazebosim/gz-utils
+    version: gz-utils2

--- a/gazebo.repos
+++ b/gazebo.repos
@@ -1,8 +1,4 @@
 repositories:
-  ros_gz:
-    type: git
-    url: https://github.com/gazebosim/ros_gz
-    version: ros2
   gz-sim:
     type: git
     url: https://github.com/gazebosim/gz-sim


### PR DESCRIPTION
This PR adds the `gazebo.repos` file that was referenced and merged into the README previously :facepalm: . The idea is to build Gazebo Garden from source in a separate workspace, and overlay the `vehicle_gateway` workspace on top of it, so that rebuilds are much faster.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>