### PR TITLE
Added aerial widgets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,10 @@ jobs:
           required-ros-distributions: humble
       - name: checkout
         uses: actions/checkout@v2
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt update -qq
+          apt install -qq -y lsb-release wget curl gnupg2
       - name: build
         uses: ros-tooling/action-ros-ci@v0.2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,8 @@ jobs:
         with:
           required-ros-distributions: humble
       - name: checkout
-        uses: actions/checkout@v2
-        id: configure
-        run: |
+      - uses: actions/checkout@v2
+      - run: |
           export DEBIAN_FRONTEND=noninteractive
           apt update -qq
           apt install -qq -y lsb-release wget curl gnupg2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
           required-ros-distributions: humble
       - name: checkout
         uses: actions/checkout@v2
-        run: |
+      - run: |
           export DEBIAN_FRONTEND=noninteractive
           apt update -qq
           apt install -qq -y lsb-release wget curl gnupg2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,14 @@ jobs:
           required-ros-distributions: humble
       - name: checkout
         uses: actions/checkout@v2
+        id: configure
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          apt update -qq
+          apt install -qq -y lsb-release wget curl gnupg2
+          wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg &&
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+          apt-get update && apt-get install gz-garden
       - name: build
         uses: ros-tooling/action-ros-ci@v0.2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: ros-tooling/action-ros-ci@v0.2
         with:
           package-name: |
+            gz_aerial_widgets
             vehicle_gateway
             vehicle_gateway_px4
           vcs-repo-file-url: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: ros-tooling/action-ros-ci@v0.2
         with:
           package-name: |
-            gz_aerial_widgets
+            gz_aerial_plugins
             vehicle_gateway
             vehicle_gateway_px4
           vcs-repo-file-url: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
           apt install -qq -y lsb-release wget curl gnupg2
           wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
-          apt-get update && apt-get install gz-garden
+          apt-get update && apt-get install -qq -y gz-garden
       - name: build
         uses: ros-tooling/action-ros-ci@v0.2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,14 +18,7 @@ jobs:
         with:
           required-ros-distributions: humble
       - name: checkout
-      - uses: actions/checkout@v2
-      - run: |
-          export DEBIAN_FRONTEND=noninteractive
-          apt update -qq
-          apt install -qq -y lsb-release wget curl gnupg2
-          wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
-          apt-get update && apt-get install gz-garden
+        uses: actions/checkout@v2
       - name: build
         uses: ros-tooling/action-ros-ci@v0.2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           apt update -qq
           apt install -qq -y lsb-release wget curl gnupg2
-          wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg &&
+          wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
           apt-get update && apt-get install gz-garden
       - name: build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,9 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           apt update -qq
           apt install -qq -y lsb-release wget curl gnupg2
+          wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+          apt-get update && apt-get install gz-garden
       - name: build
         uses: ros-tooling/action-ros-ci@v0.2
         with:

--- a/gz_aerial_plugins/CMakeLists.txt
+++ b/gz_aerial_plugins/CMakeLists.txt
@@ -1,0 +1,80 @@
+cmake_minimum_required(VERSION 3.8)
+project(gz_aerial_plugins)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+if(POLICY CMP0100)
+  cmake_policy(SET CMP0100 NEW)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+
+set(CMAKE_AUTOMOC ON)
+set(OpenGL_GL_PREFERENCE LEGACY)
+
+# Find Qt5
+find_package(Qt5
+  COMPONENTS
+    Core
+    Quick
+    QuickControls2
+  REQUIRED
+)
+
+#============================================================================
+# Find gz-cmake
+#============================================================================
+# If you get an error at this line, you need to install gz-cmake
+find_package(gz-cmake3 REQUIRED)
+
+# Find the Ignition gui library
+#--------------------------------------
+# Find gz-gui
+gz_find_package(gz-gui7 REQUIRED)
+set(GZ_GUI_VER ${gz-gui7_VERSION_MAJOR})
+
+#--------------------------------------
+# Find gz-common
+# Always use the profiler component to get the headers, regardless of status.
+gz_find_package(gz-common5
+  REQUIRED
+)
+set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
+
+qt5_add_resources(resources_rcc src/DroneHmi.qrc)
+
+include_directories(SYSTEM
+  ${Qt5Core_INCLUDE_DIRS}
+  ${Qt5Qml_INCLUDE_DIRS}
+  ${Qt5Quick_INCLUDE_DIRS}
+  ${Qt5QuickControls2_INCLUDE_DIRS}
+)
+
+# Generate examples
+add_library(DroneHmi SHARED ${headers_MOC}
+  src/DroneHmi.cpp
+  ${resources_rcc}
+)
+target_link_libraries(DroneHmi
+  gz-gui7::gz-gui7
+  gz-common5::gz-common5
+  ${Qt5Core_LIBRARIES}
+  ${Qt5Qml_LIBRARIES}
+  ${Qt5Quick_LIBRARIES}
+  ${Qt5QuickControls2_LIBRARIES}
+)
+
+install(
+  TARGETS DroneHmi
+  DESTINATION share/${PROJECT_NAME}/lib
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/gz_aerial_plugins/package.xml
+++ b/gz_aerial_plugins/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>gz_aerial_plugins</name>
+  <version>0.0.0</version>
+  <description>Drone Gazebo Simulator GUI Plugins</description>
+  <maintainer email="ahcorde@openrobotics.com">ahcorde</maintainer>
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>gz-cmake3</buildtool_depend>
+  <buildtool_depend>gz-gui7</buildtool_depend>
+  <buildtool_depend>gz-msgs9</buildtool_depend>
+  <buildtool_depend>gz-common5</buildtool_depend>
+  <depend>qml-module-qtquick-extras</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/gz_aerial_plugins/src/AttitudeWidget.qml
+++ b/gz_aerial_plugins/src/AttitudeWidget.qml
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Open Source Robotics Foundation
+ * Copyright (C) 2023 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gz_aerial_plugins/src/AttitudeWidget.qml
+++ b/gz_aerial_plugins/src/AttitudeWidget.qml
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2018 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtQuick.Controls.Material 2.1
+import QtQuick.Layouts 1.3
+
+Rectangle {
+  id: "imageDisplay"
+  color: "transparent"
+  anchors.fill: parent
+  Layout.minimumWidth: 200
+  Layout.minimumHeight: 200
+
+  Connections {
+    target: DroneHmi
+    onNewImage: image.reload();
+  }
+
+  ColumnLayout {
+    id: imageDisplayColumn
+    anchors.fill: parent
+    anchors.margins: 10
+
+    Image {
+      id: image
+      cache: false
+      fillMode: Image.PreserveAspectFit
+      Layout.fillHeight: true
+      Layout.fillWidth: true
+      verticalAlignment: Image.AlignTop
+      horizontalAlignment: Image.AlignLeft
+      function reload() {
+        console.log("update")
+        // Force image request to C++
+        source = "image://attitudedisplay/" + Math.random().toString(36).substr(2, 5);
+      }
+    }
+  }
+}

--- a/gz_aerial_plugins/src/CompassWidget.qml
+++ b/gz_aerial_plugins/src/CompassWidget.qml
@@ -1,0 +1,80 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtQuick.Controls.Material 2.1
+import QtQuick.Controls.Styles 1.4
+import QtQuick.Layouts 1.3
+import "qrc:/qml"
+
+Rectangle
+{
+  id: compassWidget
+  width: 150
+  height: 150
+
+  Canvas
+  {
+    id: canvas
+    anchors.fill: parent
+
+    property double angle_: 0;
+    property double margins_: 10.0;
+    property variant pointText_:  ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
+
+    Connections {
+      target: DroneHmi
+      onNewHeading: {
+        canvas.angle_ = DroneHmi.heading
+        canvas.requestPaint();
+      }
+    }
+
+    onPaint : {
+      var ctx = getContext("2d");
+      ctx.reset()
+      ctx.translate(compassWidget.width / 2, compassWidget.height / 2);
+      var scaleCompass = Math.min((compassWidget.width  - margins_)/120.0,
+                                  (compassWidget.height - margins_)/120.0);
+      ctx.scale(scale, scale);
+
+      var i = 0;
+      var j = 0;
+      while(i < 360)
+      {
+        if(i % 45 == 0)
+        {
+          ctx.beginPath();
+          ctx.fillStyle = "black";
+          ctx.fillText(qsTr(pointText_[j]), -5, -52);
+          ctx.moveTo(0, -40);
+          ctx.lineTo(0, -50);
+          ctx.moveTo(0, -40);
+          ctx.stroke();
+          j++;
+        }
+        else
+        {
+          ctx.beginPath();
+          ctx.moveTo(0, -45);
+          ctx.lineTo(0, -50);
+          ctx.stroke();
+        }
+        ctx.rotate(15 * 3.1416 / 180);
+        i += 15;
+      }
+
+      ctx.lineWidth = 4
+      ctx.strokeStyle = "black"
+      ctx.fillStyle = "red"
+      ctx.rotate(canvas.angle_);
+      ctx.beginPath();
+      ctx.moveTo(-10, 0);
+      ctx.lineTo(0, -45);
+      ctx.lineTo(10, 0);
+      ctx.lineTo(0, -15);
+      ctx.lineTo(-10, 0);
+      ctx.closePath();
+      ctx.fill();
+      ctx.stroke();
+    }
+  }
+}

--- a/gz_aerial_plugins/src/CompassWidget.qml
+++ b/gz_aerial_plugins/src/CompassWidget.qml
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
 import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.1

--- a/gz_aerial_plugins/src/DroneHmi.config
+++ b/gz_aerial_plugins/src/DroneHmi.config
@@ -1,0 +1,2 @@
+<plugin filename="DroneHmi">
+</plugin>

--- a/gz_aerial_plugins/src/DroneHmi.cpp
+++ b/gz_aerial_plugins/src/DroneHmi.cpp
@@ -1,0 +1,390 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "DroneHmi.hpp"
+
+#include <QQuickImageProvider>
+#include <QPainter>
+
+#include <algorithm>
+
+#include <gz/common/Console.hh>
+#include <gz/gui/Application.hh>
+#include <gz/gui/MainWindow.hh>
+#include <gz/plugin/Register.hh>
+
+namespace gz
+{
+namespace aerial
+{
+namespace plugins
+{
+class ImageProvider : public QQuickImageProvider
+{
+public:
+  ImageProvider()
+  : QQuickImageProvider(QQuickImageProvider::Image)
+  {
+  }
+
+public:
+  QImage requestImage(
+    const QString &, QSize *,
+    const QSize &) override
+  {
+    if (!this->img.isNull()) {
+      // Must return a copy
+      QImage copy(this->img);
+      return copy;
+    }
+
+    // Placeholder in case we have no image yet
+    QImage i(200, 200, QImage::Format_RGB888);
+    i.fill(QColor(128, 128, 128, 100));
+    return i;
+  }
+
+public:
+  void SetImage(const QImage & _image)
+  {
+    this->img = _image;
+  }
+
+private:
+  QImage img;
+};
+
+class AttitudeDisplayPrivate
+{
+  /// \brief To provide images for QML.
+
+public:
+  ImageProvider * provider{nullptr};
+  double roll{0.0};
+  double pitch{0.0};
+  double offset{0.0};
+  double size{200 - 4};
+
+  QBrush bgGround;
+
+  QPen blackPen;
+  QPen pitchPen;
+  QPen pitchZero;
+
+  QImage * image;
+  double angle{0};
+};
+
+DroneHmi::DroneHmi()
+: gz::gui::Plugin(), dataPtr(new AttitudeDisplayPrivate)
+{
+}
+
+DroneHmi::~DroneHmi()
+{
+  gz::gui::App()->Engine()->removeImageProvider("attitudedisplay");
+}
+
+void DroneHmi::LoadConfig(const tinyxml2::XMLElement * _pluginElem)
+{
+  if (!_pluginElem) {
+    return;
+  }
+
+  if (this->title.empty()) {
+    this->title = "Drone HMI";
+  }
+
+  this->dataPtr->bgGround = QBrush(QColor(0, 147, 57));
+
+  this->dataPtr->blackPen.setWidth(2);
+  this->dataPtr->pitchZero.setWidth(3);
+
+  this->dataPtr->pitchPen.setColor(Qt::white);
+  this->dataPtr->blackPen.setColor(Qt::black);
+  this->dataPtr->pitchZero.setColor(Qt::green);
+
+  this->dataPtr->image = new QImage(200, 200, QImage::Format_RGB888);
+
+  this->dataPtr->provider = new ImageProvider();
+  gz::gui::App()->Engine()->addImageProvider("attitudedisplay", this->dataPtr->provider);
+
+  std::string topic{"heading"};
+  std::string topicPitch{"pitch"};
+  std::string topicRoll{"roll"};
+
+  // Subscribe to new topic
+  if (!this->node_.Subscribe(
+      topic, &DroneHmi::onHeadingReceived,
+      this))
+  {
+    gzerr << "Unable to subscribe to topic [" << topic << "]" << std::endl;
+    return;
+  }
+
+  if (!this->node_.Subscribe(
+      topicPitch, &DroneHmi::onPitchReceived,
+      this))
+  {
+    gzerr << "Unable to subscribe to topic [" << topic << "]" << std::endl;
+    return;
+  }
+
+  if (!this->node_.Subscribe(
+      topicRoll, &DroneHmi::onRollReceived,
+      this))
+  {
+    gzerr << "Unable to subscribe to topic [" << topic << "]" << std::endl;
+    return;
+  }
+}
+
+void DroneHmi::onPitchReceived(const gz::msgs::Float & _msg)
+{
+  this->dataPtr->pitch = _msg.data();
+}
+
+void DroneHmi::onRollReceived(const gz::msgs::Float & _msg)
+{
+  this->dataPtr->roll = _msg.data();
+}
+
+void DroneHmi::onHeadingReceived(const gz::msgs::Float & _msg)
+{
+  this->SetHeading(_msg.data());
+  this->newHeading();
+}
+
+void DroneHmi::SetHeading(const double _angle)
+{
+  this->dataPtr->angle = _angle;
+  this->Update();
+}
+
+double DroneHmi::Heading()
+{
+  return this->dataPtr->angle;
+}
+
+void DroneHmi::Update()
+{
+  QPainter painter(this->dataPtr->image);
+
+  painter.setRenderHint(QPainter::Antialiasing);
+
+  painter.translate(200 / 2, 200 / 2);
+  painter.rotate(this->dataPtr->roll);
+
+  DrawBackground(painter);
+  DrawPitch(painter);
+  DrawRoll(painter);
+
+  this->dataPtr->provider->SetImage(*this->dataPtr->image);
+  this->newImage();
+}
+
+void DroneHmi::DrawBackground(QPainter & painter)
+{
+  double y_min, y_max;
+
+  y_min = this->dataPtr->size / 2 * -40.0 / 45.0;
+  y_max = this->dataPtr->size / 2 * 40.0 / 45.0;
+
+  double y = this->dataPtr->size / 2 * -this->dataPtr->pitch / 45.;
+  if (y < y_min) {
+    y = y_min;
+  }
+  if (y > y_max) {
+    y = y_max;
+  }
+
+  int x = sqrt(this->dataPtr->size * this->dataPtr->size / 4 - y * y);
+  qreal gr = atan(y / x);
+  gr = gr * 180. / 3.1415926;
+
+  painter.setPen(QPen(Qt::black));
+  painter.setBrush(QColor(48, 172, 220));
+  painter.drawChord(
+    -this->dataPtr->size / 2, -this->dataPtr->size / 2,
+    this->dataPtr->size, this->dataPtr->size,
+    gr * 16, (180 - 2 * gr) * 16);
+
+  painter.setBrush(this->dataPtr->bgGround);
+  painter.drawChord(
+    -this->dataPtr->size / 2, -this->dataPtr->size / 2,
+    this->dataPtr->size, this->dataPtr->size,
+    gr * 16, -(180 + 2 * gr) * 16);
+}
+
+void DroneHmi::DrawPitch(QPainter & painter)
+{
+  // std::lock_guard<std::mutex> lock(mutex);
+
+  // set mask
+  QRegion maskRegion(-this->dataPtr->size / 2,
+    -this->dataPtr->size / 2,
+    this->dataPtr->size,
+    this->dataPtr->size,
+    QRegion::Ellipse);
+  painter.setClipRegion(maskRegion);
+
+  int x, y, x1, y1;
+  int textWidth;
+  double p, r;
+  int ll = this->dataPtr->size / 8, l;
+
+  int fontSize = 8;
+  QString s;
+
+  this->dataPtr->pitchPen.setWidth(2);
+  painter.setFont(QFont("", fontSize));
+
+  // draw lines
+  for (int i = -9; i <= 9; ++i) {
+    p = i * 10;
+    s = QString("%1").arg(-p);
+
+    if (i % 3 == 0) {
+      l = ll;
+    } else {
+      l = ll / 2;
+    }
+
+    if (i == 0) {
+      painter.setPen(this->dataPtr->pitchZero);
+      l = l * 1.8;
+    } else {
+      painter.setPen(this->dataPtr->pitchPen);
+    }
+
+    y = this->dataPtr->size / 2 * p / 45.0 -
+      this->dataPtr->size / 2 * -this->dataPtr->pitch / 45.;
+    x = l;
+
+    r = sqrt(x * x + y * y);
+    if (r > this->dataPtr->size / 2) {continue;}
+
+    painter.drawLine(QPointF(-l, 1.0 * y), QPointF(l, 1.0 * y));
+
+    textWidth = 100;
+
+    if (i % 3 == 0 && i != 0) {
+      painter.setPen(QPen(Qt::white));
+
+      x1 = -x - 2 - textWidth;
+      y1 = y - fontSize / 2 - 1;
+      painter.drawText(
+        QRectF(x1, y1, textWidth, fontSize + 2),
+        Qt::AlignRight | Qt::AlignVCenter, s);
+    }
+  }
+
+  // draw marker
+  float markerSize = this->dataPtr->size / 20.0;
+  float fx1, fy1, fx2, fy2, fx3, fy3;
+
+  painter.setBrush(QBrush(Qt::red));
+  painter.setPen(Qt::NoPen);
+
+  fx1 = markerSize;
+  fy1 = 0;
+  fx2 = fx1 + markerSize;
+  fy2 = -markerSize / 2;
+  fx3 = fx1 + markerSize;
+  fy3 = markerSize / 2;
+
+  QPointF points[3] = {
+    QPointF(fx1, fy1),
+    QPointF(fx2, fy2),
+    QPointF(fx3, fy3)
+  };
+  painter.drawPolygon(points, 3);
+
+  QPointF points2[3] = {
+    QPointF(-fx1, fy1),
+    QPointF(-fx2, fy2),
+    QPointF(-fx3, fy3)
+  };
+  painter.drawPolygon(points2, 3);
+}
+
+void DroneHmi::DrawRoll(QPainter & painter)
+{
+  // std::lock_guard<std::mutex> lock(mutex);
+
+  int nRollLines = 36;
+  float rotAng = 360.0 / nRollLines;
+  int rollLineLeng = this->dataPtr->size / 25;
+  double fx1, fy1, fx2, fy2, fx3, fy3;
+  int fontSize = 8;
+  QString s;
+
+  this->dataPtr->blackPen.setWidth(1);
+  painter.setPen(this->dataPtr->blackPen);
+  painter.setFont(QFont("", fontSize));
+
+  for (int i = 0; i < nRollLines; i++) {
+    if (i < nRollLines / 2) {
+      s = QString("%1").arg(-i * rotAng);
+    } else {
+      s = QString("%1").arg(360 - i * rotAng);
+    }
+
+    fx1 = 0;
+    fy1 = -this->dataPtr->size / 2 + this->dataPtr->offset;
+    fx2 = 0;
+
+    if (i % 3 == 0) {
+      fy2 = fy1 + rollLineLeng;
+      painter.drawLine(QPointF(fx1, fy1), QPointF(fx2, fy2));
+
+      fy2 = fy1 + rollLineLeng + 2;
+      painter.drawText(
+        QRectF(-50, fy2, 100, fontSize + 2),
+        Qt::AlignCenter, s);
+    } else {
+      fy2 = fy1 + rollLineLeng / 2;
+      painter.drawLine(QPointF(fx1, fy1), QPointF(fx2, fy2));
+    }
+
+    painter.rotate(rotAng);
+  }
+
+  // draw roll marker
+  int rollMarkerSize = this->dataPtr->size / 25;
+
+  painter.rotate(-this->dataPtr->roll);
+  painter.setBrush(QBrush(Qt::black));
+
+  fx1 = 0;
+  fy1 = -this->dataPtr->size / 2 + this->dataPtr->offset;
+  fx2 = fx1 - rollMarkerSize / 2;
+  fy2 = fy1 + rollMarkerSize;
+  fx3 = fx1 + rollMarkerSize / 2;
+  fy3 = fy1 + rollMarkerSize;
+
+  QPointF points[3] = {
+    QPointF(fx1, fy1),
+    QPointF(fx2, fy2),
+    QPointF(fx3, fy3)
+  };
+  painter.drawPolygon(points, 3);
+}
+
+}  // namespace plugins
+}  // namespace aerial
+}  // namespace gz
+
+// Register this plugin
+GZ_ADD_PLUGIN(gz::aerial::plugins::DroneHmi, gz::gui::Plugin)

--- a/gz_aerial_plugins/src/DroneHmi.hpp
+++ b/gz_aerial_plugins/src/DroneHmi.hpp
@@ -1,0 +1,97 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#ifndef DRONEHMI_HPP_
+#define DRONEHMI_HPP_
+
+#include <gz/gui/qt.h>
+
+#include <gz/msgs/float.pb.h>
+
+#include <memory>
+#include <string>
+
+#include <gz/gui/Plugin.hh>
+#include <gz/transport/Node.hh>
+
+namespace gz
+{
+namespace aerial
+{
+namespace plugins
+{
+
+class AttitudeDisplayPrivate;
+
+class DroneHmi : public gz::gui::Plugin
+{
+  Q_OBJECT
+
+public:
+  /// \brief Constructor
+  DroneHmi();
+
+  /// \brief Destructor
+  virtual ~DroneHmi();
+
+  /// \brief Called by Gazebo GUI when plugin is instantiated.
+  /// \param[in] _pluginElem XML configuration for this plugin.
+  void LoadConfig(const tinyxml2::XMLElement * _pluginElem) override;
+
+  /// \brief Notify that a new image has been received.
+
+  void Update();
+
+  void drawRoll(QPainter & painter);
+  void drawPitch(QPainter & painter);
+  void DrawBackground(QPainter & painter);
+
+  /// \brief Frequency
+  Q_PROPERTY(
+    double heading
+    READ Heading
+    WRITE SetHeading
+    NOTIFY newHeading
+  )
+
+public:
+  double Heading();
+
+public:
+  Q_INVOKABLE void SetHeading(const double);
+
+signals:
+  void newImage();
+  void newHeading();
+
+private:
+  gz::transport::Node node_;
+
+  void onHeadingReceived(const gz::msgs::Float & _msg);
+  void onPitchReceived(const gz::msgs::Float & _msg);
+  void onRollReceived(const gz::msgs::Float & _msg);
+
+  /// \internal
+  /// \brief Pointer to private data.
+
+private:
+  std::unique_ptr<AttitudeDisplayPrivate> dataPtr;
+};
+
+}  // namespace plugins
+}  // namespace aerial
+}  // namespace gz
+
+#endif  // DRONEHMI_HPP_

--- a/gz_aerial_plugins/src/DroneHmi.hpp
+++ b/gz_aerial_plugins/src/DroneHmi.hpp
@@ -54,8 +54,8 @@ public:
 
   void Update();
 
-  void drawRoll(QPainter & painter);
-  void drawPitch(QPainter & painter);
+  void DrawRoll(QPainter & painter);
+  void DrawPitch(QPainter & painter);
   void DrawBackground(QPainter & painter);
 
   /// \brief Frequency

--- a/gz_aerial_plugins/src/DroneHmi.qml
+++ b/gz_aerial_plugins/src/DroneHmi.qml
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2023 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
 import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Controls.Material 2.1

--- a/gz_aerial_plugins/src/DroneHmi.qml
+++ b/gz_aerial_plugins/src/DroneHmi.qml
@@ -1,0 +1,18 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtQuick.Controls.Material 2.1
+import QtQuick.Controls.Styles 1.4
+import QtQuick.Layouts 1.3
+import "qrc:/qml"
+import "qrc:/CompassWidget"
+import "qrc:/AttitudeWidget"
+
+RowLayout
+{
+  Layout.minimumWidth: 400
+  Layout.minimumHeight: 250
+
+  AttitudeWidget{}
+
+  CompassWidget{}
+}

--- a/gz_aerial_plugins/src/DroneHmi.qrc
+++ b/gz_aerial_plugins/src/DroneHmi.qrc
@@ -1,0 +1,13 @@
+<!DOCTYPE RCC><RCC version="1.0">
+  <qresource prefix="DroneHmi/">
+    <file>DroneHmi.qml</file>
+  </qresource>
+
+  <qresource prefix="CompassWidget">
+    <file>CompassWidget.qml</file>
+  </qresource>
+
+  <qresource prefix="AttitudeWidget">
+    <file>AttitudeWidget.qml</file>
+  </qresource>
+</RCC>


### PR DESCRIPTION
Signed-off-by: Alejandro Hernández Cordero <ahcorde@gmail.com>

This PR adds two widgets
 - compass
 - roll and pitch visualizer

there are three topics that we can use
 - `heading` (used by the compass
 - `roll` and `pitch`

![Gazebo GUI_001](https://user-images.githubusercontent.com/1933907/212957118-6bdabb26-646c-438f-aca4-1ce08709b483.png)

## Test it

```bash
export GZ_GUI_PLUGIN_PATH=`pwd`/install/share/gazebo_gui_plugins/lib; gz gui -s DroneHmi
```

```bash
gz topic -t pitch -m gz.msgs.Float -p 'data: 45'
gz topic -t roll -m gz.msgs.Float -p 'data: 15'
gz topic -t heading -m gz.msgs.Float -p 'data: 25'
```
