### PR TITLE
Build Gazebo only once

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ We can now build the Vehicle Gateway itself, by overlaying its workspace on top 
 cd ~/vg/vg_ws
 rosdep update && rosdep install --from-paths src --ignore-src -y
 source ~/vg/gz_ws/install/setup.bash
-colcon build
+colcon build --event-handlers console_direct+
 ```
 
 # Run a PX4 Quadcopter demo

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ cd ~/vg/vg_ws/src
 git clone https://github.com/osrf/vehicle_gateway
 cd ~/vg/vg_ws
 vcs import src < src/vehicle_gateway/dependencies.repos
-vcs import src < src/vehicle_gateway/gazebo.repos
 ```
 
 Next, build Gazebo Garden from source. The full instructions are [here](https://gazebosim.org/docs/garden/install_ubuntu_src), and summarized in the following command sequence:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cd ~/vg/vg_ws
 vcs import src < src/vehicle_gateway/dependencies.repos
 ```
 
-Next, build Gazebo Garden from source. The full instructions are [here](https://gazebosim.org/docs/garden/install_ubuntu_src), and summarized in the following command sequence:
+Next, build Gazebo Garden from source, using some specific branches in some repositories that are currently required for this project. The precise arrangement of branches is described in the `gazebo.repos` file which will be used by the command sequence below. The full instructions are [here](https://gazebosim.org/docs/garden/install_ubuntu_src), and summarized as follows:
 
 ```bash
 mkdir -p ~/vg/gz_ws/src
@@ -53,7 +53,7 @@ We can now build the Vehicle Gateway itself, by overlaying its workspace on top 
 cd ~/vg/vg_ws
 rosdep update && rosdep install --from-paths src --ignore-src -y
 source ~/vg/gz_ws/install/setup.bash
-colcon build --merge-install --event-handlers console_direct+
+colcon build
 ```
 
 # Run a PX4 Quadcopter demo


### PR DESCRIPTION
Currently our top-level README instructions result in Gazebo being built twice: once in the `vg/gz_ws` and once in the `vg/vg_ws` workspaces. This PR removes the Gazebo source install in `vg/vg_ws` so that the Gazebo packages are only built once in the underlay workspace `vg/gz_ws` to speed up recompiles in the overlay `vg/vg_ws` workspace.

Since the overlay workspace `vg/vg_ws` will then only have ROS packages in it, it can be built using the standard `colcon build` incantation, without needing `--merge-install`