### PR TITLE
suggest removing humble-supplied gazebo bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sudo apt-get update
 sudo apt-get install gz-garden
 ```
 
-Because the ros-gz bridge that ships with ROS 2 Humble targets the previous version of Gazebo (Fortress), we will remove it and build our own version of the ROS-Gazebo link packages in the next section. To avoid some warning about having multiple versions of those packages, you can remove them from your ROS 2 Humble installation:
+Because the `ros_gz` bridge that ships with ROS 2 Humble targets the previous version of Gazebo (Fortress), we will remove it and build our own version of the ROS-Gazebo link packages in the next section. To avoid some warning about having multiple versions of those packages, you can remove them from your ROS 2 Humble installation:
 ```bash
 sudo apt remove ros-humble-ros-gz-bridge
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ sudo apt-get update
 sudo apt-get install gz-garden
 ```
 
+Because the ros-gz bridge that ships with ROS 2 Humble targets the previous version of Gazebo (Fortress), we will remove it and build our own version of the ROS-Gazebo link packages in the next section. To avoid some warning about having multiple versions of those packages, you can remove them from your ROS 2 Humble installation:
+```bash
+sudo apt remove ros-humble-ros-gz-bridge
+```
+
 ### Build the Vehicle Gateway
 We can now build the Vehicle Gateway itself. To keep paths short, we will make a colcon workspace named `vg` for "Vehicle Gateway", in your home directory. The Vehicle Gateway build will also download and build the PX4 firmware, to allow software-in-the-loop (SITL) simulation.
 


### PR DESCRIPTION
When compiling this repo with a system that has `ros-humble-desktop-full` installed, it will print warnings because our workspace is building `ros-humble-ros-gz-bridge` (and a few related packages in `ros-gz` repo) with the same name as the packages installed in `/opt/ros/humble` that link against Gazebo Fortress.

Maybe this is OK? But it seems nice to remove the system-supplied packages in this underlay workspace to avoid the warnings. This doc change suggests to do that. However, this will cause the `ros-humble-desktop-full` metapackage to be uninstalled, so then if anybody does `sudo apt autoremove` it would remove basically all the ROS 2 Humble packages. So... I'm actually not sure if this is a good idea to suggest that people uninstall the Humble-supplied ros-gz package. If there isn't any problems with building and running it in our overlay workspace, maybe we could just note this warning will be generated and tell users to ignore it? @ahcorde @jennuine what do you think?