### PR TITLE
add dependencies for PX4

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We can now build the Vehicle Gateway itself. To keep paths short, we will make a
 At time of writing, the `rosdep` command has to include a lot of `--skip-key` because currently Gazebo Garden is not yet in `rosdep`.
 
 ```bash
-sudo apt install python3-kconfiglib python3-jinja2 python3-jsonschema ros-humble-gps-msgs gcc-arm-none-eabi libfuse2 python3-pip git python3-vcstool python3-future
+sudo apt install python3-kconfiglib python3-jinja2 python3-jsonschema ros-humble-gps-msgs gcc-arm-none-eabi libfuse2 python3-pip git python3-vcstool python3-future rsync
 pip3 install pyros-genmsg
 mkdir -p ~/vg/src
 cd ~/vg/src

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ cd ~/vg/src
 git clone https://github.com/osrf/vehicle_gateway
 cd ~/vg
 vcs import src < src/vehicle_gateway/dependencies.repos
-rosdep update && rosdep install --from-paths src --ignore-src -y --skip-keys="gz-transport12 gz-common5 gz-math7 gz-msgs9 gz-gui7 gz-cmake3 gz-sim7"
 source /opt/ros/humble/setup.bash
+rosdep update && rosdep install --from-paths src --ignore-src -y --skip-keys="gz-transport12 gz-common5 gz-math7 gz-msgs9 gz-gui7 gz-cmake3 gz-sim7"
 colcon build --event-handlers console_direct+
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We can now build the Vehicle Gateway itself. To keep paths short, we will make a
 At time of writing, the `rosdep` command has to include a lot of `--skip-key` because currently Gazebo Garden is not yet in `rosdep`.
 
 ```bash
-sudo apt install python3-kconfiglib python3-jinja2 python3-jsonschema ros-humble-gps-msgs gcc-arm-none-eabi libfuse2 python3-pip git python3-vcstool
+sudo apt install python3-kconfiglib python3-jinja2 python3-jsonschema ros-humble-gps-msgs gcc-arm-none-eabi libfuse2 python3-pip git python3-vcstool python3-future
 pip3 install pyros-genmsg
 mkdir -p ~/vg/src
 cd ~/vg/src


### PR DESCRIPTION
I'm not sure if this was just because of the way I was building it (using distrobox), but I needed to add these `rsync` and `python3-future` to the system for PX4 to build. I also needed to change the order of the `rosdep` invocation so that it happened after sourcing the binary-installed ROS 2 humble, not before. 