### PR TITLE
Null Island simulation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ In the event that you need or want to test out pre-release changes that are only
 
 # Run a PX4 Quadcopter demo
 
+### Start the simulation
+
 Now that the software stack is built, we can do some fun and interesting things! Here is a minimal example that runs the PX4 software-in-the-loop (SITL) in an empty Gazebo world. Gazebo is used to generate all the sensors used to feed the PX4, and the PX4 SITL actuator commands are simulated by the Gazebo physics engine:
 
 ```bash
 cd ~/vg
 source install/setup.bash
-ros2 launch px4_sim px4_sim.launch.py drone_type:='x500'
+ros2 launch px4_sim px4_sim.launch.py drone_type:=x500
 ```
 
 For a more visually-interesting world that can be used for simulating vision-guided experiments, we created Null Island, a tiny island with a few launch pads for small drones. The launch pad can be selected as a command-line parameter to `ros2 launch` as shown here:
@@ -81,7 +83,16 @@ For a more visually-interesting world that can be used for simulating vision-gui
 ```bash
 cd ~/vg
 source install/setup.bash
-ros2 launch px4_sim px4_sim.launch.py drone_type:='x500' position_name:=pad_1 world_name:=null_island
+ros2 launch px4_sim px4_sim.launch.py drone_type:=x500 frame_name:=pad_1 world_name:=null_island
+```
+
+### Fly!
+
+Once the simulation world is up and running, there should be a simulated autopilot running that you can communicate with using the Vehicle Gateway API. In a separate terminal, you can run a minimal takeoff-land script that uses this API:
+```bash
+cd ~/vg
+source install/setup.bash
+python3 src/vehicle_gateway/vehicle_gateway_python/examples/test_takeoff_land.py
 ```
 
 # Running tests

--- a/vehicle_gateway_worlds/worlds/null_island.sdf
+++ b/vehicle_gateway_worlds/worlds/null_island.sdf
@@ -144,7 +144,6 @@
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
           <property type="double" key="height">72</property>
-          <property type="double" key="width">121</property>
           <property type="double" key="z">1</property>
 
           <property type="string" key="state">floating</property>

--- a/vehicle_gateway_worlds/worlds/null_island.sdf
+++ b/vehicle_gateway_worlds/worlds/null_island.sdf
@@ -26,6 +26,10 @@
       filename="gz-sim-air-speed-system"
       name="gz::sim::systems::AirSpeed">
     </plugin>
+    <plugin
+      name='gz::sim::systems::AirPressure'
+      filename='gz-sim-air-pressure-system'>
+    </plugin>
 
     <scene>
       <clouds/>
@@ -267,6 +271,22 @@
           <property key="height" type="double">5</property>
           <property key="state" type="string">floating</property>
           <property key="showTitleBar" type="bool">false</property>
+        </gz-gui>
+      </plugin>
+
+      <!-- Inspector -->
+      <plugin filename="ComponentInspector" name="Component inspector">
+        <gz-gui>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="string" key="state">docked</property>
+        </gz-gui>
+      </plugin>
+
+      <!-- Entity tree -->
+      <plugin filename="EntityTree" name="Entity tree">
+        <gz-gui>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="string" key="state">docked</property>
         </gz-gui>
       </plugin>
     </gui>


### PR DESCRIPTION
 * Update README to add a command to run a minimal takeoff-land Python script
 * Update README to fix the Null Island simulation launch command example
 * Instantiate the barometric plugin in the Null Island world
 * Instantiate the GUI plugins for component tree and inspector in the Null Island World