### PR TITLE
Run CI tests repeatedly up to 5x until they pass + other minor improvements to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,33 +28,29 @@ jobs:
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
           apt-get update && apt-get install -qq -y gz-garden
       - name: Build and test
-        uses: Wandalen/wretry.action@master
+        uses: ros-tooling/action-ros-ci@v0.2
         with:
-          action: ros-tooling/action-ros-ci@v0.2
-          attempt_limit: 3
-          attempt_delay: 2000
-          with: |
-            package-name: |
-              betaflight_configurator
-              betaflight_controller
-              betaflight_demo
-              betaflight_gazebo
-              gz_aerial_plugins
-              vehicle_gateway
-              vehicle_gateway_betaflight
-              vehicle_gateway_px4
-              vehicle_gateway_python
-              vehicle_gateway_worlds
-              vehicle_gateway_integration_test
-              px4_sim
-            vcs-repo-file-url: |
-              $GITHUB_WORKSPACE/dependencies.repos
-            target-ros2-distro: humble
-            colcon-defaults: |
-              {
-                "build": {
-                  "cmake-args": [
-                    "tt-DSKIP_QGROUNDCONTROL=1"
-                  ]
-                }
+          package-name: |
+            betaflight_configurator
+            betaflight_controller
+            betaflight_demo
+            betaflight_gazebo
+            gz_aerial_plugins
+            vehicle_gateway
+            vehicle_gateway_betaflight
+            vehicle_gateway_px4
+            vehicle_gateway_python
+            vehicle_gateway_worlds
+            vehicle_gateway_integration_test
+            px4_sim
+          vcs-repo-file-url: |
+            $GITHUB_WORKSPACE/dependencies.repos
+          target-ros2-distro: humble
+          colcon-defaults: |
+            {
+              "build": {
+                "cmake-args": [
+                  "-DSKIP_QGROUNDCONTROL=1"
+                ]
               }
+            }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,5 +52,8 @@ jobs:
                 "cmake-args": [
                   "-DSKIP_QGROUNDCONTROL=1"
                 ]
+              },
+              "test": {
+                "retest-until-pass": 5
               }
             }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,38 @@ jobs:
           wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
           apt-get update && apt-get install -qq -y gz-garden
-      - name: Build and test
+      - name: Build
         uses: ros-tooling/action-ros-ci@v0.2
         with:
+          skip-tests: true
+          package-name: |
+            betaflight_configurator
+            betaflight_controller
+            betaflight_demo
+            betaflight_gazebo
+            gz_aerial_plugins
+            vehicle_gateway
+            vehicle_gateway_betaflight
+            vehicle_gateway_px4
+            vehicle_gateway_python
+            vehicle_gateway_worlds
+            vehicle_gateway_integration_test
+            px4_sim
+          vcs-repo-file-url: |
+            $GITHUB_WORKSPACE/dependencies.repos
+          target-ros2-distro: humble
+          colcon-defaults: |
+            {
+              "build": {
+                "cmake-args": [
+                  "-DSKIP_QGROUNDCONTROL=1"
+                ]
+              }
+            }
+      - name: Test
+        uses: ros-tooling/action-ros-ci@v0.2
+        with:
+          skip-tests: false
           package-name: |
             betaflight_configurator
             betaflight_controller

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,29 +28,33 @@ jobs:
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
           apt-get update && apt-get install -qq -y gz-garden
       - name: Build and test
-        uses: ros-tooling/action-ros-ci@v0.2
+        uses: Wandalen/wretry.action@master
         with:
-          package-name: |
-            betaflight_configurator
-            betaflight_controller
-            betaflight_demo
-            betaflight_gazebo
-            gz_aerial_plugins
-            vehicle_gateway
-            vehicle_gateway_betaflight
-            vehicle_gateway_px4
-            vehicle_gateway_python
-            vehicle_gateway_worlds
-            vehicle_gateway_integration_test
-            px4_sim
-          vcs-repo-file-url: |
-            $GITHUB_WORKSPACE/dependencies.repos
-          target-ros2-distro: humble
-          colcon-defaults: |
-            {
-              "build": {
-                "cmake-args": [
-                  "-DSKIP_QGROUNDCONTROL=1"
-                ]
+          action: ros-tooling/action-ros-ci@v0.2
+          attempt_limit: 3
+          attempt_delay: 2000
+          with: |
+            package-name: |
+              betaflight_configurator
+              betaflight_controller
+              betaflight_demo
+              betaflight_gazebo
+              gz_aerial_plugins
+              vehicle_gateway
+              vehicle_gateway_betaflight
+              vehicle_gateway_px4
+              vehicle_gateway_python
+              vehicle_gateway_worlds
+              vehicle_gateway_integration_test
+              px4_sim
+            vcs-repo-file-url: |
+              $GITHUB_WORKSPACE/dependencies.repos
+            target-ros2-distro: humble
+            colcon-defaults: |
+              {
+                "build": {
+                  "cmake-args": [
+                    "tt-DSKIP_QGROUNDCONTROL=1"
+                  ]
+                }
               }
-            }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
   push:
     branches: [ main ]
+  schedule:
+    - cron: "0 0 * * *"
 defaults:
   run:
     shell: bash
@@ -26,7 +28,7 @@ jobs:
           wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
           apt-get update && apt-get install -qq -y gz-garden
-      - name: build
+      - name: build and test
         uses: ros-tooling/action-ros-ci@v0.2
         with:
           package-name: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
           apt-get update && apt-get install -qq -y gz-garden
       - name: Build and test
-        uses: ros-tooling/action-ros-ci@v0.2
+        uses: ros-tooling/action-ros-ci@v0.3
         with:
           package-name: |
             betaflight_configurator

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,13 +13,13 @@ jobs:
     container:
       image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
-      - name: setup ROS 2
+      - name: Setup ROS 2
         uses: ros-tooling/setup-ros@v0.3
         with:
           required-ros-distributions: humble
-      - name: checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v3
-      - name: install gazebo
+      - name: Install gazebo
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt update -qq
@@ -27,7 +27,7 @@ jobs:
           wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
           apt-get update && apt-get install -qq -y gz-garden
-      - name: build and test
+      - name: Build and test
         uses: ros-tooling/action-ros-ci@v0.2
         with:
           package-name: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,38 +27,9 @@ jobs:
           wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
           apt-get update && apt-get install -qq -y gz-garden
-      - name: Build
+      - name: Build and test
         uses: ros-tooling/action-ros-ci@v0.2
         with:
-          skip-tests: true
-          package-name: |
-            betaflight_configurator
-            betaflight_controller
-            betaflight_demo
-            betaflight_gazebo
-            gz_aerial_plugins
-            vehicle_gateway
-            vehicle_gateway_betaflight
-            vehicle_gateway_px4
-            vehicle_gateway_python
-            vehicle_gateway_worlds
-            vehicle_gateway_integration_test
-            px4_sim
-          vcs-repo-file-url: |
-            $GITHUB_WORKSPACE/dependencies.repos
-          target-ros2-distro: humble
-          colcon-defaults: |
-            {
-              "build": {
-                "cmake-args": [
-                  "-DSKIP_QGROUNDCONTROL=1"
-                ]
-              }
-            }
-      - name: Test
-        uses: ros-tooling/action-ros-ci@v0.2
-        with:
-          skip-tests: false
           package-name: |
             betaflight_configurator
             betaflight_controller

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,13 +13,14 @@ jobs:
     container:
       image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
-      - name: deps
+      - name: setup ROS 2
         uses: ros-tooling/setup-ros@v0.3
         with:
           required-ros-distributions: humble
-      - name: checkout
+      - name: checkout repository
         uses: actions/checkout@v3
-      - run: |
+      - name: install gazebo
+        run: |
           export DEBIAN_FRONTEND=noninteractive
           apt update -qq
           apt install -qq -y lsb-release wget curl gnupg2 python3-kconfiglib python3-jinja2 python3-jsonschema ros-humble-gps-msgs gcc-arm-none-eabi libfuse2 python3-pip python3-future rsync python3-genmsg

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,6 @@
 name: build
 on:
-  pull_request:
   push:
-    branches: [ main ]
   schedule:
     - cron: "0 0 * * *"
 defaults:


### PR DESCRIPTION
This PR runs CI tests repeatedly up to 5 times until CI passes. While not ideal because it takes a while (30 minutes to fail becomes ~ 40 minutes to pass), it should help us have green CI so we know if we introduce regressions.

Also, this PR adds a few minor changes:
- Triggers CI on all pushes, not just pull requests or to master
- Run CI nightly, so we can see repeating failures
- Updates the version of action-ros-ci to v0.3 - which prints the test results
- Minor textual improvements in CI

I also tried a few things that didn't work:
- Retrying the action on failure using  `Wandalen/wretry.action@master` which seemed to be the only one I found that was supposed to work for actions, not just steps. It has failing CI, so maybe it's broken. 0c516b3
- Splitting the build and test step: I tried ignoring the tests in the first run and then testing them in the second. I was hoping that the building the second time would be faster, since they had already built. It doesn't seem like this was true, and runtime was almost double. It is nice to split them up, but I don't think it's worth doubling the time d144da6.
  - I learned a good bit about action-ros-ci during this process.