### PR TITLE
canceling the executor many times seems to help shutdown

### DIFF
--- a/vehicle_gateway_integration_test/test/script/arm_disarm.py
+++ b/vehicle_gateway_integration_test/test/script/arm_disarm.py
@@ -20,10 +20,6 @@ import vehicle_gateway
 from vehicle_gateway import ArmingState
 
 vg = vehicle_gateway.init(args=sys.argv, plugin_type='px4')
-while vg.get_arming_state() != ArmingState.STANDBY:
-    vg.disarm()
-    time.sleep(0.1)
-
 while vg.get_arming_state() != ArmingState.ARMED:
     vg.arm()
     time.sleep(0.1)

--- a/vehicle_gateway_integration_test/test/script/takeoff_land.py
+++ b/vehicle_gateway_integration_test/test/script/takeoff_land.py
@@ -39,7 +39,7 @@ while vg.get_altitude() < -1.0:
     sys.stdout.flush()
     time.sleep(0.25)
 
-print("landed. Disarming...")
+print('Landed. Disarming...')
 sys.stdout.flush()
 
 while vg.get_arming_state() != ArmingState.STANDBY:

--- a/vehicle_gateway_integration_test/test/script/takeoff_land.py
+++ b/vehicle_gateway_integration_test/test/script/takeoff_land.py
@@ -23,17 +23,24 @@ from vehicle_gateway import ArmingState
 vg = vehicle_gateway.init(args=sys.argv, plugin_type='px4')
 while vg.get_arming_state() != ArmingState.ARMED:
     vg.arm()
-    time.sleep(0.1)
+    time.sleep(0.5)
 
 vg.takeoff()
 
-while vg.get_altitude() > -2.0:
-    time.sleep(0.1)
+while vg.get_altitude() > -3.0:
+    print(f'altitude: {vg.get_altitude()}')
+    sys.stdout.flush()
+    time.sleep(0.25)
 
 vg.land()
 
-while vg.get_altitude() < -0.3:
-    time.sleep(0.1)
+while vg.get_altitude() < -1.0:
+    print(f'altitude: {vg.get_altitude()}')
+    sys.stdout.flush()
+    time.sleep(0.25)
+
+print("landed. Disarming...")
+sys.stdout.flush()
 
 while vg.get_arming_state() != ArmingState.STANDBY:
     vg.disarm()

--- a/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
+++ b/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
@@ -306,7 +306,11 @@ void VehicleGatewayPX4::destroy()
     // we've asked it to shut down many times, so clearly now we're good lol
     this->exec_ = nullptr;
     rclcpp::shutdown();
+    printf("calling std::thread::join()\n");
+    fflush(stdout);
     this->spin_thread_.join();
+    printf("done with std::thread::join()\n");
+    fflush(stdout);
   }
 }
 

--- a/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
+++ b/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
@@ -298,7 +298,12 @@ vehicle_gateway::FAILURE VehicleGatewayPX4::get_failure()
 void VehicleGatewayPX4::destroy()
 {
   if (this->exec_) {
-    this->exec_->cancel();
+    // this is the type of code you write just before the velociraptors attack
+    for (int i = 0; i < 42; i++) {
+      this->exec_->cancel();
+      usleep(100);  // sleep a bit to force a thread context switch
+    }
+    // we've asked it to shut down many times, so clearly now we're good lol
     this->exec_ = nullptr;
     rclcpp::shutdown();
     this->spin_thread_.join();


### PR DESCRIPTION
I'm not sure why, but it seems if we call `cancel()` and `usleep()` many times on the MultiThreadedExecutor, that helps it not hang when we try to `join()` its thread.