### PR TITLE
calculate PX4_SYS_AUTOSTART value during launch using a substitution

### DIFF
--- a/vehicle_gateway_models/models/standard_vtol_camera/model.config
+++ b/vehicle_gateway_models/models/standard_vtol_camera/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+  <name>standard_vtol_camera</name>
+  <version>1.0</version>
+  <sdf version="1.9">model.sdf</sdf>
+
+  <author>
+    <name>Morgan Quigley</name>
+    <email>morgan@openrobotics.org</email>
+  </author>
+
+  <description>
+    standard_vtol with camera
+  </description>
+</model>

--- a/vehicle_gateway_models/models/standard_vtol_camera/model.sdf
+++ b/vehicle_gateway_models/models/standard_vtol_camera/model.sdf
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sdf version='1.9'>
+  <model name='standard_vtol_camera'>
+
+    <plugin filename="gz-sim-pose-publisher-system" name="gz::sim::systems::PosePublisher">
+      <publish_link_pose>true</publish_link_pose>
+      <publish_nested_model_pose>true</publish_nested_model_pose>
+      <use_pose_vector_msg>true</use_pose_vector_msg>
+      <update_frequency>30</update_frequency>
+    </plugin>
+
+    <include merge="true">
+      <uri>model://standard_vtol</uri>
+    </include>
+
+    <include merge="true">
+      <uri>model://camera</uri>
+    </include>
+
+    <joint name="camera_joint" type="fixed">
+      <parent>base_link</parent>
+      <child>camera_link</child>
+    </joint>
+
+  </model>
+</sdf>


### PR DESCRIPTION
Currently in `px4_sim.launch.py` the value of PX4_SYS_AUTOSTART is hard-coded to `4001`, which works great for x500 (quadcopter). We need to calculate this on-the-fly to support dynamic spawning of more than one model type. This PR adds a bit of substitution hackery using a `PythonExpression` to look up the requested `drone_type` parameter into a Python dictionary to find the necessary `PX4_SYS_AUTOSTART` , which is currently either 4001 for x500, or 4004 for `standard_vtol`. This makes the px4_sim launch command work for standard_vtol, which can then take off and fly around as a multicopter:
```
ros2 launch px4_sim px4_sim.launch.py drone_type:=standard_vtol
```
then, in another terminal window:
```
python3 src/vehicle_gateway/vehicle_gateway_python/examples/test_takeoff_land.py
```