### PR TITLE
Some CI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,5 +44,8 @@ jobs:
               },
               "test": {
                 "retest-until-pass": 5
+              },
+              "test": {
+                "packages-select-regex": "vehicle_gateway"
               }
             }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,8 @@ jobs:
                 "retest-until-pass": 5
               },
               "test": {
-                "packages-select-regex": "vehicle_gateway"
+                "packages-select-regex": [
+                  "vehicle_gateway"
+                ]
               }
             }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,22 +30,11 @@ jobs:
       - name: Build and test
         uses: ros-tooling/action-ros-ci@v0.3
         with:
-          package-name: |
-            betaflight_configurator
-            betaflight_controller
-            betaflight_demo
-            betaflight_gazebo
-            gz_aerial_plugins
-            vehicle_gateway
-            vehicle_gateway_betaflight
-            vehicle_gateway_px4
-            vehicle_gateway_python
-            vehicle_gateway_worlds
-            vehicle_gateway_integration_test
-            px4_sim
+          package-name:
           vcs-repo-file-url: |
             $GITHUB_WORKSPACE/dependencies.repos
           target-ros2-distro: humble
+          rosdep-skip-keys: gz-transport12 gz-common5 gz-math7 gz-msgs9 gz-gui7 gz-cmake3 gz-sim7
           colcon-defaults: |
             {
               "build": {

--- a/vehicle_gateway_demo/CMakeLists.txt
+++ b/vehicle_gateway_demo/CMakeLists.txt
@@ -21,8 +21,8 @@ ament_target_dependencies(aruco_demo
   control_toolbox
   rclcpp
   std_msgs
-	vehicle_gateway_px4
-	aruco_opencv_msgs
+  vehicle_gateway_px4
+  aruco_opencv_msgs
 )
 
 add_executable(circles
@@ -35,7 +35,7 @@ ament_target_dependencies(circles
 
 install(DIRECTORY
   launch
-	config
+  config
   DESTINATION
     share/${PROJECT_NAME}
 )


### PR DESCRIPTION
Changes:
- Building all packages in the repo by default https://github.com/ros-tooling/action-ros-ci/blob/master/action.yml#L46
- Added rosdep-skip-keys to match the build steps from README
- colcon test only `vehicle_gateway_*` packages [note this won't be visible in the colcon test command running in CI but the behavior is as expected]