### PR TITLE
Defined get_vtol_status

### DIFF
--- a/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
+++ b/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
@@ -360,6 +360,11 @@ vehicle_gateway::ARMING_STATE VehicleGatewayPX4::get_arming_state()
   return this->arming_state_;
 }
 
+vehicle_gateway::VTOL_STATE VehicleGatewayPX4::get_vtol_state()
+{
+  return this->vtol_state_;
+}
+
 void VehicleGatewayPX4::send_command(
   uint32_t command, uint8_t target_system, uint8_t target_component, uint8_t source_system,
   uint8_t source_component, uint8_t confirmation, bool from_external,

--- a/vehicle_gateway_python/src/vehicle_gateway_python/vehicle_gateway.cpp
+++ b/vehicle_gateway_python/src/vehicle_gateway_python/vehicle_gateway.cpp
@@ -236,7 +236,10 @@ define_vehicle_gateway(py::object module)
     "Land")
   .def(
     "get_altitude", &VehicleGatewayPython::GetAltitude,
-    "Get altitude in meter");
+    "Get altitude in meter")
+  .def(
+    "get_vtol_state", &VehicleGatewayPython::GetVtolState,
+    "Get VTOL state");
 
   pybind11::enum_<vehicle_gateway::ARMING_STATE>(module, "ArmingState")
   .value("INIT", vehicle_gateway::ARMING_STATE::INIT)


### PR DESCRIPTION
Was missing from https://github.com/osrf/vehicle_gateway/pull/75

without, `test_takeoff_land.py` produced the following error:
```
Traceback (most recent call last):
  File "/home/jennuine/Workspaces/vg/src/vehicle_gateway/vehicle_gateway_python/examples/test_takeoff_land.py", line 20, in <module>
    px4_gateway = vehicle_gateway.init(args=sys.argv, plugin_type='px4')
  File "/home/jennuine/Workspaces/vg/install/vehicle_gateway_python/local/lib/python3.10/dist-packages/vehicle_gateway/__init__.py", line 33, in init
    return _vehicle_gateway.VehicleGatewayPython(args, plugin_type)
RuntimeError: Failed to load library /home/jennuine/Workspaces/vg/install/vehicle_gateway_px4/lib/libvehicle_gateway_px4.so. Make sure that you are calling the PLUGINLIB_EXPORT_CLASS macro in the library code, and that names are consistent between this macro and your XML. Error string: Could not load library dlopen error: /home/jennuine/Workspaces/vg/install/vehicle_gateway_px4/lib/libvehicle_gateway_px4.so: undefined symbol: _ZN19vehicle_gateway_px417VehicleGatewayPX414get_vtol_stateEv, at ./src/shared_library.c:99
```