### PR TITLE
Fixed python import VtolState

### DIFF
--- a/vehicle_gateway_python/vehicle_gateway/__init__.py
+++ b/vehicle_gateway_python/vehicle_gateway/__init__.py
@@ -23,6 +23,7 @@ FlightMode = _vehicle_gateway.FlightMode
 Failure = _vehicle_gateway.Failure
 VehicleType = _vehicle_gateway.VehicleType
 ControllerType = _vehicle_gateway.ControllerType
+VtolState = _vehicle_gateway.VtolState
 
 
 def init(


### PR DESCRIPTION
Was missing from https://github.com/osrf/vehicle_gateway/pull/75

Before PR, could not `from vehicle_gateway import VtolState`