### PR TITLE
use fields in vehicle_status to derive vtol status

### DIFF
--- a/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
+++ b/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
@@ -232,10 +232,11 @@ void VehicleGatewayPX4::init(int argc, const char ** argv)
       // Use several fields in vehicle_status to determine vtol state since
       // it seems that /fmu/out/vtol_vehicle_status is no longer being sent (?)
       if (msg->in_transition_mode) {
-        if (msg->in_transition_to_fw)
+        if (msg->in_transition_to_fw) {
           this->vtol_state_ = vehicle_gateway::VTOL_STATE::TRANSITION_TO_FW;
-        else
+        } else {
           this->vtol_state_ = vehicle_gateway::VTOL_STATE::TRANSITION_TO_MC;
+        }
       } else {
         switch (msg->vehicle_type) {
           case px4_msgs::msg::VehicleStatus::VEHICLE_TYPE_ROTARY_WING:

--- a/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
+++ b/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
@@ -228,31 +228,25 @@ void VehicleGatewayPX4::init(int argc, const char ** argv)
         default:
           this->flight_mode_ = vehicle_gateway::FLIGHT_MODE::UNKNOWN_MODE;
       }
-    });
 
-  this->vtol_vehicle_status_sub_ =
-    this->px4_node_->create_subscription<px4_msgs::msg::VtolVehicleStatus>(
-    "/fmu/out/vtol_vehicle_status",
-    qos_profile,
-    [this](px4_msgs::msg::VtolVehicleStatus::ConstSharedPtr msg) {
-      switch (msg->vehicle_vtol_state) {
-        case px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_UNDEFINED:
-          this->vtol_state_ = vehicle_gateway::VTOL_STATE::UNDEFINED;
-          break;
-        case px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_TRANSITION_TO_FW:
+      // Use several fields in vehicle_status to determine vtol state since
+      // it seems that /fmu/out/vtol_vehicle_status is no longer being sent (?)
+      if (msg->in_transition_mode) {
+        if (msg->in_transition_to_fw)
           this->vtol_state_ = vehicle_gateway::VTOL_STATE::TRANSITION_TO_FW;
-          break;
-        case px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_TRANSITION_TO_MC:
+        else
           this->vtol_state_ = vehicle_gateway::VTOL_STATE::TRANSITION_TO_MC;
-          break;
-        case px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_MC:
-          this->vtol_state_ = vehicle_gateway::VTOL_STATE::MC;
-          break;
-        case px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_FW:
-          this->vtol_state_ = vehicle_gateway::VTOL_STATE::FW;
-          break;
-        default:
-          this->vtol_state_ = vehicle_gateway::VTOL_STATE::UNDEFINED;
+      } else {
+        switch (msg->vehicle_type) {
+          case px4_msgs::msg::VehicleStatus::VEHICLE_TYPE_ROTARY_WING:
+            this->vtol_state_ = vehicle_gateway::VTOL_STATE::MC;
+            break;
+          case px4_msgs::msg::VehicleStatus::VEHICLE_TYPE_FIXED_WING:
+            this->vtol_state_ = vehicle_gateway::VTOL_STATE::FW;
+            break;
+          default:
+            this->vtol_state_ = vehicle_gateway::VTOL_STATE::UNDEFINED;
+        }
       }
     });
 


### PR DESCRIPTION
It seems that the `/fmu/out/vtol_status` topic isn't always coming through to ROS for some reason; not sure if anything changed or exactly what's going on. This PR simplifies things a bit by using some fields in the `VehicleStatus` message in the `/fmu/out/vehicle_status` topic to derive the VTOL status, rather than requiring a separate subscription to the `vtol_status` topic.