### PR TITLE
Capturing test exit codes

### DIFF
--- a/vehicle_gateway_integration_test/test/script/arm_disarm.py
+++ b/vehicle_gateway_integration_test/test/script/arm_disarm.py
@@ -31,6 +31,6 @@ while vg.get_arming_state() != ArmingState.STANDBY:
     time.sleep(0.1)
 
 # TODO(quarkytale): remove
-pytest.fail(f"This is a test for capturing process exit codes.")
+pytest.fail("This is a test for capturing process exit codes.")
 
 vg.destroy()

--- a/vehicle_gateway_integration_test/test/script/arm_disarm.py
+++ b/vehicle_gateway_integration_test/test/script/arm_disarm.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 import sys
 import time
 
@@ -27,5 +29,8 @@ while vg.get_arming_state() != ArmingState.ARMED:
 while vg.get_arming_state() != ArmingState.STANDBY:
     vg.disarm()
     time.sleep(0.1)
+
+# TODO(quarkytale): remove
+pytest.fail(f"This is a test for capturing process exit codes.")
 
 vg.destroy()

--- a/vehicle_gateway_integration_test/test/script/arm_disarm.py
+++ b/vehicle_gateway_integration_test/test/script/arm_disarm.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 import sys
 import time
 
@@ -29,8 +27,5 @@ while vg.get_arming_state() != ArmingState.ARMED:
 while vg.get_arming_state() != ArmingState.STANDBY:
     vg.disarm()
     time.sleep(0.1)
-
-# TODO(quarkytale): remove
-pytest.fail("This is a test for capturing process exit codes.")
 
 vg.destroy()

--- a/vehicle_gateway_integration_test/test/test_px4.py
+++ b/vehicle_gateway_integration_test/test/test_px4.py
@@ -137,6 +137,8 @@ class TestFixture(unittest.TestCase):
             launch_service, proc_action, proc_info, proc_output
         ):
             proc_info.assertWaitForShutdown(process=proc_action, timeout=300)
+            launch_testing.asserts.assertExitCodes(proc_info, process=proc_action,
+                                                   allowable_exit_codes=[0])
 
         # shutdown px4
         p = subprocess.Popen('px4-shutdown',
@@ -156,4 +158,5 @@ class TestHelloWorldShutdown(unittest.TestCase):
 
     def test_exit_codes(self, proc_info, run_px4):
         """Check if the processes exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info, process=run_px4)
+        launch_testing.asserts.assertExitCodes(proc_info, process=run_px4,
+                                               allowable_exit_codes=[0])


### PR DESCRIPTION
Added `assertExitCodes` test right after each test in `vehicle_gateway_integration_test/test/script/` to capture result and get an indication in CI.