### PR TITLE
Set airspeed to 10 to not trigger quadshoot

### DIFF
--- a/vehicle_gateway_python/examples/mc_to_fw_to_offboard.py
+++ b/vehicle_gateway_python/examples/mc_to_fw_to_offboard.py
@@ -160,7 +160,7 @@ while True:
     if dist < 20:
         break
     # I don't know why you have to repeatedly send this, but it seems necessary
-    px4_gateway.set_air_speed(14)
+    px4_gateway.set_air_speed(10)
     time.sleep(0.1)
 
 print('Transitioning to multicopter...')


### PR DESCRIPTION
The quadshoot seems to trigger with higher airspeeds. It doesn't seem to happen with an airspeed of 10. 