### PR TITLE
allow PX4 to slow down for nice FW-MC transitions

### DIFF
--- a/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
+++ b/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
@@ -525,7 +525,7 @@ void VehicleGatewayPX4::transition_to_mc()
     this->confirmation_,
     this->from_external_,
     vehicle_gateway::VTOL_STATE::MC,  // The target VTOL state
-    1.0f);  // Force immediate transition to the specified MAV_VTOL_STATE
+    0.0f);  // don't force immediate transition; allow PX4 to slow down first
 }
 
 void VehicleGatewayPX4::go_to_latlon(double lat, double lon, float alt_amsl)


### PR DESCRIPTION
Fixes #89  . Previously we were asking PX4 for an "immediate" FW->MC transition. Unless airspeed was already really really low, this would cause a dramatic pitch-up which would trigger quad-chute mode. This one-line change just tells PX4 we don't need an immediate transition, and we'd instead like to wait to slow down first :smile:  With this parameter setting, we don't have to handle the slowdown ourselves, and PX4 will do it nicely for each airframe's specific parameter tuning.