### PR TITLE
pin version of ros_gz to avoid issue on ros2 branch

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -2,7 +2,7 @@ repositories:
   ros_gz:
     type: git
     url: https://github.com/gazebosim/ros_gz
-    version: ros2
+    version: 7c62a1ce3cfb4eb3b54e1cfd092c9b63a9d5f255
   uros/micro_ros_msgs:
     type: git
     url: https://github.com/micro-ROS/micro_ros_msgs.git


### PR DESCRIPTION
At time of writing, the `ros2` branch of `ros_gz` has a dependency on `actuator_msgs`, but that package is not available in the main binary repos yet. To avoid making a special-case on that package and building it from source, we can sidestep this issue for now just by pinning the version of `ros_gz` before this dependency was introduce. Once the release repos include `actuator_msgs` we can update the pinned version, or switch back to tracking the `ros2` branch of `ros_gz`