### PR TITLE
assign NaN's to uncontrolled fields of position mode

### DIFF
--- a/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
+++ b/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
@@ -581,6 +581,19 @@ void VehicleGatewayPX4::set_local_position_setpoint(float x, float y, float z, f
   msg.position[1] = y;
   msg.position[2] = z;
   msg.yaw = yaw;
+
+  // non-NaN velocity and acceleration fields are used as feedforward terms.
+  // We will just set them all to NaN, to keep this API simple.
+
+  msg.velocity[0] = std::numeric_limits<float>::quiet_NaN();
+  msg.velocity[1] = std::numeric_limits<float>::quiet_NaN();
+  msg.velocity[2] = std::numeric_limits<float>::quiet_NaN();
+  msg.yawspeed = std::numeric_limits<float>::quiet_NaN();
+
+  msg.acceleration[0] = std::numeric_limits<float>::quiet_NaN();
+  msg.acceleration[1] = std::numeric_limits<float>::quiet_NaN();
+  msg.acceleration[2] = std::numeric_limits<float>::quiet_NaN();
+
   this->vehicle_trajectory_setpoint_pub_->publish(msg);
 }
 

--- a/vehicle_gateway_python/src/vehicle_gateway_python/vehicle_gateway.cpp
+++ b/vehicle_gateway_python/src/vehicle_gateway_python/vehicle_gateway.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <limits>
 #include <pybind11/pybind11.h>
 #include <vector>
 
@@ -286,7 +287,11 @@ define_vehicle_gateway(py::object module)
     "GetLatLon")
   .def(
     "set_local_position_setpoint", &VehicleGatewayPython::PublishLocalPositionSetpoint,
-    "PublishLocalPositionSetpoint")
+    "PublishLocalPositionSetpoint",
+    py::arg("x"),
+    py::arg("y"),
+    py::arg("z"),
+    py::arg("yaw") = std::numeric_limits<float>::quiet_NaN())
   .def(
     "set_local_velocity_setpoint", &VehicleGatewayPython::PublishLocalVelocitySetpoint,
     "PublishLocalVelocitySetpoint")

--- a/vehicle_gateway_python/src/vehicle_gateway_python/vehicle_gateway.cpp
+++ b/vehicle_gateway_python/src/vehicle_gateway_python/vehicle_gateway.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <limits>
 #include <pybind11/pybind11.h>
+
+#include <limits>
 #include <vector>
 
 #include "exceptions.hpp"


### PR DESCRIPTION
Previously some unused setpoint fields were assigned to zero, but instead they need to be assigned to `NaN` to avoid winding up controllers unintentionally.