### PR TITLE
Pin PX4 to most recent commit

### DIFF
--- a/px4_sim/CMakeLists.txt
+++ b/px4_sim/CMakeLists.txt
@@ -13,7 +13,7 @@ externalproject_add(px4-firmware
   GIT_REPOSITORY
     https://github.com/PX4/PX4-Autopilot
   GIT_TAG
-    main
+    3cc940cb06f233a22a8d1b948bc05f067491e212
   INSTALL_COMMAND
     mkdir -p ${CMAKE_INSTALL_PREFIX}/share/px4_sim &&
     rsync -avL --exclude .git --exclude build


### PR DESCRIPTION
I pinned PX4 in this PR so things don't break unexpectedly because PX4 is under active development. 

I tried pinning to PX4's [latest stable tag](https://github.com/PX4/PX4-Autopilot/releases/tag/v1.13.3) but was having trouble cloning pymavlink and so the build wouldn't complete. I'm not 100% sure why this is.

In the future, perhaps we pin to the next stable release of PX4.

This should go in after #98 (and CI should be rerun). 