### PR TITLE
build zenoh and POC program

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install rust
         run: |
           apt install curl
-          curl https://sh.rustup.rs -sSf | sh
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Install gazebo
         run: |
           export DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,12 @@ jobs:
           apt install curl
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           source $HOME/.cargo/env
+          echo ". $HOME/.cargo/env" >> ~/.bashrc
+          echo $HOME
+          rustc --version
+          cargo --version
+      - name: Test rust tools
+        run: |
           rustc --version
           cargo --version
       - name: Install gazebo
@@ -48,9 +54,6 @@ jobs:
                 "cmake-args": [
                   "-DSKIP_QGROUNDCONTROL=1"
                 ],
-                "hooks": [
-                  "$HOME/.cargo/env"
-                ]
               },
               "test": {
                 "retest-until-pass": 5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,14 +20,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install rust
-        run: |
-          apt install curl
-          curl https://sh.rustup.rs -sSf | sh -s -- -y
-          source $HOME/.cargo/env
-          echo ". $HOME/.cargo/env" >> ~/.bashrc
-          echo $HOME
-          rustc --version
-          cargo --version
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          override: true
+          components: rustfmt, clippy
       - name: Test rust tools
         run: |
           rustc --version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,7 @@ jobs:
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           source $HOME/.cargo/env
           rustc --version
+          cargo --version
       - name: Install gazebo
         run: |
           export DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,9 @@ jobs:
               "build": {
                 "cmake-args": [
                   "-DSKIP_QGROUNDCONTROL=1"
+                ],
+                "hooks": [
+                  "$HOME/.cargo/env",
                 ]
               },
               "test": {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
                   "-DSKIP_QGROUNDCONTROL=1"
                 ],
                 "hooks": [
-                  "$HOME/.cargo/env",
+                  "$HOME/.cargo/env"
                 ]
               },
               "test": {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
         run: |
           apt install curl
           curl https://sh.rustup.rs -sSf | sh -s -- -y
+          source $HOME/.cargo/env
+          rustc --version
       - name: Install gazebo
         run: |
           export DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
               "build": {
                 "cmake-args": [
                   "-DSKIP_QGROUNDCONTROL=1"
-                ],
+                ]
               },
               "test": {
                 "retest-until-pass": 5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,10 @@ jobs:
           required-ros-distributions: humble
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Install rust
+        run: |
+          apt install curl
+          curl https://sh.rustup.rs -sSf | sh
       - name: Install gazebo
         run: |
           export DEBIAN_FRONTEND=noninteractive

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Because the `ros_gz` bridge that ships with ROS 2 Humble targets the previous ve
 sudo apt remove ros-humble-ros-gz-bridge
 ```
 
+### Install Rust
+Zenoh is used for vehicle-to-vehicle communications. Because Zenoh is implemented in Rust, it is necessary to install a Rust toolchain in order to build it:
+```bash
+sudo apt install curl
+curl https://sh.rustup.rs -sSf | sh
+```
+
 ### Build the Vehicle Gateway
 We can now build the Vehicle Gateway itself. To keep paths short, we will make a colcon workspace named `vg` for "Vehicle Gateway", in your home directory. The Vehicle Gateway build will also download and build the PX4 firmware and Betaflight firmware, to allow software-in-the-loop (SITL) simulation of multiple autopilot software stacks.
 

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: https://github.com/christianrauch/msp
     version: master
+  zenohc:
+    type: git
+    url: https://github.com/eclipse-zenoh/zenoh-c
+    version: 0.7.1-rc

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -22,4 +22,4 @@ repositories:
   zenohc:
     type: git
     url: https://github.com/eclipse-zenoh/zenoh-c
-    version: 0.7.1-rc
+    version: master

--- a/vehicle_gateway_multi/CMakeLists.txt
+++ b/vehicle_gateway_multi/CMakeLists.txt
@@ -7,22 +7,21 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(zenohc REQUIRED)
 
 add_executable(vehicle_gateway_multi_bridge
   src/vehicle_gateway_multi_bridge.cpp
 )
-ament_target_dependencies(vehicle_gateway_multi_bridge
-  rclcpp
-  std_msgs
-)
-include_directories(zenoh)
+target_link_libraries(vehicle_gateway_multi_bridge PRIVATE
+  rclcpp::rclcpp
+  ${std_msgs_TARGETS}
+  zenohc::lib)
 
-# install(DIRECTORY
-#   launch
-#   config
-#   DESTINATION
-#     share/${PROJECT_NAME}
-# )
+install(DIRECTORY
+  config
+  DESTINATION
+    share/${PROJECT_NAME}
+)
 
 install(
   TARGETS

--- a/vehicle_gateway_multi/CMakeLists.txt
+++ b/vehicle_gateway_multi/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(vehicle_gateway_multi)
+
+find_package(ament_cmake REQUIRED)
+
+find_package(ament_cmake)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+
+add_executable(vehicle_gateway_multi_bridge
+  src/vehicle_gateway_multi_bridge.cpp
+)
+ament_target_dependencies(vehicle_gateway_multi_bridge
+  rclcpp
+  std_msgs
+)
+include_directories(zenoh)
+
+# install(DIRECTORY
+#   launch
+#   config
+#   DESTINATION
+#     share/${PROJECT_NAME}
+# )
+
+install(
+  TARGETS
+    vehicle_gateway_multi_bridge
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/vehicle_gateway_multi/config/zenoh_all_localhost.json5
+++ b/vehicle_gateway_multi/config/zenoh_all_localhost.json5
@@ -1,0 +1,13 @@
+{
+  mode: "peer",
+  connect: {
+    endpoints: [
+      "tcp/localhost:7447",
+    ],
+  },
+  listen: {
+    endpoints: [
+      "tcp/0.0.0.0:0",
+    ],
+  },
+}

--- a/vehicle_gateway_multi/package.xml
+++ b/vehicle_gateway_multi/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>vehicle_gateway_multi</name>
+  <version>0.0.0</version>
+  <description>Multiple vehicle communications for Vehicle Gateway</description>
+  <maintainer email="morgan@openrobotics.com">Morgan Quigley</maintainer>
+  <license>Apache License 2.0</license>
+
+  <author>Morgan Quigley</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>vehicle_gateway</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+
+</package>

--- a/vehicle_gateway_multi/package.xml
+++ b/vehicle_gateway_multi/package.xml
@@ -14,6 +14,7 @@
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>vehicle_gateway</depend>
+  <depend>zenohc</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>

--- a/vehicle_gateway_multi/src/vehicle_gateway_multi_bridge.cpp
+++ b/vehicle_gateway_multi/src/vehicle_gateway_multi_bridge.cpp
@@ -3,4 +3,26 @@
 
 int main(int argc, char **argv) {
   printf("hello world\n");
+  if (argc < 2) {
+    printf("usage: vehicle_gateway_multi_bridge CONFIG_FILENAME\n");
+    return EXIT_FAILURE;
+  }
+  const char *config_filename = argv[1];
+  z_owned_config_t config = zc_config_from_file(config_filename);
+  if (!z_check(config)) {
+    printf("unable to parse zenoh config from [%s]\n", config_filename);
+    return EXIT_FAILURE;
+  }
+  printf("opening zenoh session...\n");
+  z_owned_session_t session = z_open(z_move(config));
+  if (!z_check(session)) {
+    printf("unable to open zenoh session\n");
+    return EXIT_FAILURE;
+  }
+  printf("zenoh session open!\n");
+
+  printf("closing zenoh session...\n");
+  z_close(z_move(session));
+
+  return EXIT_SUCCESS;
 }

--- a/vehicle_gateway_multi/src/vehicle_gateway_multi_bridge.cpp
+++ b/vehicle_gateway_multi/src/vehicle_gateway_multi_bridge.cpp
@@ -1,13 +1,14 @@
 #include <cstdio>
 #include "zenoh.h"
 
-int main(int argc, char **argv) {
+int main(int argc, char ** argv)
+{
   printf("hello world\n");
   if (argc < 2) {
     printf("usage: vehicle_gateway_multi_bridge CONFIG_FILENAME\n");
     return EXIT_FAILURE;
   }
-  const char *config_filename = argv[1];
+  const char * config_filename = argv[1];
   z_owned_config_t config = zc_config_from_file(config_filename);
   if (!z_check(config)) {
     printf("unable to parse zenoh config from [%s]\n", config_filename);

--- a/vehicle_gateway_multi/src/vehicle_gateway_multi_bridge.cpp
+++ b/vehicle_gateway_multi/src/vehicle_gateway_multi_bridge.cpp
@@ -1,0 +1,6 @@
+#include <cstdio>
+#include "zenoh.h"
+
+int main(int argc, char **argv) {
+  printf("hello world\n");
+}

--- a/vehicle_gateway_multi/src/vehicle_gateway_multi_bridge.cpp
+++ b/vehicle_gateway_multi/src/vehicle_gateway_multi_bridge.cpp
@@ -1,3 +1,17 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <cstdio>
 #include "zenoh.h"
 

--- a/vehicle_gateway_multi/src/vehicle_gateway_multi_bridge.cpp
+++ b/vehicle_gateway_multi/src/vehicle_gateway_multi_bridge.cpp
@@ -3,7 +3,6 @@
 
 int main(int argc, char ** argv)
 {
-  printf("hello world\n");
   if (argc < 2) {
     printf("usage: vehicle_gateway_multi_bridge CONFIG_FILENAME\n");
     return EXIT_FAILURE;


### PR DESCRIPTION
Bring Zenoh (specifically, zenoh-c) into `dependencies.repos` and create a tiny POC package and program that links into it.

When Zenoh 0.7.1 is released, we should use that, but until then we'll need `master` branch of `zenoh-c` because (at time of writing) the 0.7.1-rc branch has a typo and won't build. This will be resolved in a few days, or less.