### PR TITLE
add a few named frames in empty_world

### DIFF
--- a/vehicle_gateway_worlds/worlds/empty_px4_world.sdf
+++ b/vehicle_gateway_worlds/worlds/empty_px4_world.sdf
@@ -74,5 +74,22 @@
         </visual>
       </link>
     </model>
+
+    <frame name="pad_1">
+      <pose>0.0 0.0 0.5 0.0 0.0 0.0</pose>
+    </frame>
+    <frame name="pad_2">
+      <pose>2.0 0.0 0.5 0.0 0.0 0.0</pose>
+    </frame>
+    <frame name="pad_3">
+      <pose>-2.0 0.0 0.5 0.0 0.0 0.0</pose>
+    </frame>
+    <frame name="pad_4">
+      <pose>0.0 2.0 0.5 0.0 0.0 0.0</pose>
+    </frame>
+    <frame name="pad_5">
+      <pose>0.0 -2.0 0.5 0.0 0.0 0.0</pose>
+    </frame>
+
   </world>
 </sdf>


### PR DESCRIPTION
Add a few named frames in `empty_px4_world.sdf` so this world can be used, if desired, for multi-drone launching as in #104 , in the same way that named launch frames are available in the Null Island world. This PR creates a few named launch frames separated by 2 meters each.