### PR TITLE
Adapt API to support multivehicle

### DIFF
--- a/px4_sim/launch/px4_sim.launch.py
+++ b/px4_sim/launch/px4_sim.launch.py
@@ -227,11 +227,10 @@ def generate_launch_description():
 
     wait_spawn = ExecuteProcess(cmd=["sleep", "5"])
 
-    port_micro_ros = PythonExpression(['list(range(8888, 9999))[', LaunchConfiguration('drone_id'), ']'])
     micro_ros_agent = Node(
         package='micro_ros_agent',
         executable='micro_ros_agent',
-        arguments=['udp4', '-p', port_micro_ros],
+        arguments=['udp4', '-p', '8888'],
         parameters=[{'use_sim_time': use_sim_time}],
         output='screen')
 
@@ -260,7 +259,6 @@ def generate_launch_description():
                    '-Y', model_pose_yaw])
 
     model_name_env_var = SetEnvironmentVariable('PX4_GZ_MODEL_NAME', model_name)
-    port_micro_ros_env_var = SetEnvironmentVariable('PX4_UXRCE_DDS_PORT', port_micro_ros)
 
     autostart_magic_number = PythonExpression([
         '{"x500": 4001, "rc_cessna": 4003, "standard_vtol": 4004}["',
@@ -297,7 +295,6 @@ def generate_launch_description():
         sensor_config_args,
         spawn_entity,
         model_name_env_var,
-        port_micro_ros_env_var,
         autostart_env_var,
         bridge,
         RegisterEventHandler(
@@ -315,8 +312,7 @@ def generate_launch_description():
         use_groundcontrol,
         ExecuteProcess(cmd=['QGroundControl.AppImage'],
                        condition=IfCondition(LaunchConfiguration('groundcontrol'))),
-        micro_ros_agent,
-        port_micro_ros_env_var
+        micro_ros_agent
     ])
 
     if len(command_output) == 0:

--- a/vehicle_gateway/include/vehicle_gateway/vehicle_gateway.hpp
+++ b/vehicle_gateway/include/vehicle_gateway/vehicle_gateway.hpp
@@ -119,6 +119,14 @@ public:
   /// Initialize the autopilot
   virtual void init(int argc, const char ** argv) = 0;
 
+  /// Set Vehicle ID
+  /// \param[in] _vehicle_id Vehicle ID
+  virtual void set_vehicle_id(unsigned int _vehicle_id) = 0;
+
+  /// Get Vehicle ID
+  /// \return Vehicle ID
+  virtual unsigned int get_vehicle_id() = 0;
+
   /// Destroy the gateway
   virtual void destroy() = 0;
 

--- a/vehicle_gateway_betaflight/include/vehicle_gateway_betaflight/vehicle_gateway_betaflight.hpp
+++ b/vehicle_gateway_betaflight/include/vehicle_gateway_betaflight/vehicle_gateway_betaflight.hpp
@@ -41,6 +41,12 @@ public:
   void init(int argc, const char ** argv) override;
 
   /// Documentation inherited
+  void set_vehicle_id(unsigned int _vehicle_id) override;
+
+  /// Documentation inherited
+  unsigned int get_vehicle_id() override;
+
+  /// Documentation inherited
   void destroy() override;
 
   /// Documentation inherited
@@ -161,6 +167,8 @@ private:
   float throttle_{0};
   uint16_t arm_{0};
   float altitude{0};
+
+  unsigned int vehicle_id_{0};
 
   int index_box_arm_{-1};
 };

--- a/vehicle_gateway_betaflight/src/vehicle_gateway_betaflight.cpp
+++ b/vehicle_gateway_betaflight/src/vehicle_gateway_betaflight.cpp
@@ -21,6 +21,15 @@
 
 namespace vehicle_gateway_betaflight
 {
+void VehicleGatewayBetaflight::set_vehicle_id(unsigned int _vehicle_id)
+{
+  this->vehicle_id_ = _vehicle_id;
+}
+
+unsigned int VehicleGatewayBetaflight::get_vehicle_id()
+{
+  return this->vehicle_id_;
+}
 
 void VehicleGatewayBetaflight::init(int argc, const char ** argv)
 {

--- a/vehicle_gateway_px4/include/vehicle_gateway_px4/vehicle_gateway_px4.hpp
+++ b/vehicle_gateway_px4/include/vehicle_gateway_px4/vehicle_gateway_px4.hpp
@@ -49,6 +49,12 @@ public:
   void init(int argc, const char ** argv) override;
 
   /// Documentation inherited
+  void set_vehicle_id(unsigned int _vehicle_id) override;
+
+  /// Documentation inherited
+  unsigned int get_vehicle_id() override;
+
+  /// Documentation inherited
   void destroy() override;
 
   /// Documentation inherited
@@ -218,6 +224,8 @@ private:
   uint8_t source_component_{0};
   uint8_t confirmation_{1};
   bool from_external_{true};
+
+  unsigned int vehicle_id_{0};
 
   std::chrono::time_point<std::chrono::high_resolution_clock> timestamp_;
 

--- a/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
+++ b/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
@@ -23,6 +23,16 @@
 namespace vehicle_gateway_px4
 {
 
+void VehicleGatewayPX4::set_vehicle_id(unsigned int _vehicle_id)
+{
+  this->vehicle_id_ = _vehicle_id;
+}
+
+unsigned int VehicleGatewayPX4::get_vehicle_id()
+{
+  return this->vehicle_id_;
+}
+
 void VehicleGatewayPX4::init(int argc, const char ** argv)
 {
   if (argc != 0 && argv != nullptr) {
@@ -41,8 +51,18 @@ void VehicleGatewayPX4::init(int argc, const char ** argv)
   // Guaranteed delivery is needed to send messages to late-joining subscriptions.
   .best_effort();
 
+  std::string vehicle_id_prefix{};
+
+  if (this->vehicle_id_ != 0)
+  {
+    vehicle_id_prefix = "/px4_" + std::to_string(this->vehicle_id_);
+    this->target_system_ = this->vehicle_id_ + 1;
+  }
+
+  std::cerr << "vehicle_id_prefix " << vehicle_id_prefix << '\n';
+
   this->vehicle_status_sub_ = this->px4_node_->create_subscription<px4_msgs::msg::VehicleStatus>(
-    "/fmu/out/vehicle_status",
+    vehicle_id_prefix + "/fmu/out/vehicle_status",
     qos_profile,
     [this](px4_msgs::msg::VehicleStatus::ConstSharedPtr msg) {
       auto set_arm_disarm_reason = [](uint8_t reason)
@@ -254,7 +274,7 @@ void VehicleGatewayPX4::init(int argc, const char ** argv)
     });
 
   this->vehicle_sensor_gps_sub_ = this->px4_node_->create_subscription<px4_msgs::msg::SensorGps>(
-    "/fmu/out/vehicle_gps_position",
+    vehicle_id_prefix + "/fmu/out/vehicle_gps_position",
     qos_profile,
     [this](px4_msgs::msg::SensorGps::ConstSharedPtr msg) {
       // 1e-7 and 1e-3 comes from:
@@ -265,7 +285,7 @@ void VehicleGatewayPX4::init(int argc, const char ** argv)
     });
 
   this->vehicle_timesync_sub_ = this->px4_node_->create_subscription<px4_msgs::msg::TimesyncStatus>(
-    "/fmu/out/timesync_status",
+    vehicle_id_prefix + "/fmu/out/timesync_status",
     qos_profile,
     [this](px4_msgs::msg::TimesyncStatus::ConstSharedPtr msg) {
       this->timestamp_ = std::chrono::time_point<std::chrono::high_resolution_clock>(
@@ -274,7 +294,7 @@ void VehicleGatewayPX4::init(int argc, const char ** argv)
 
   this->vehicle_odometry_sub_ =
     this->px4_node_->create_subscription<px4_msgs::msg::VehicleOdometry>(
-    "/fmu/out/vehicle_odometry",
+    vehicle_id_prefix + "/fmu/out/vehicle_odometry",
     qos_profile,
     [this](px4_msgs::msg::VehicleOdometry::ConstSharedPtr msg) {
       this->odom_timestamp_ = std::chrono::time_point<std::chrono::high_resolution_clock>(
@@ -306,23 +326,25 @@ void VehicleGatewayPX4::init(int argc, const char ** argv)
 
   this->airspeed_sub_ =
     this->px4_node_->create_subscription<px4_msgs::msg::Airspeed>(
-    "/fmu/out/airspeed",
+    vehicle_id_prefix + "/fmu/out/airspeed",
     qos_profile,
     [this](px4_msgs::msg::Airspeed::ConstSharedPtr msg) {
       this->airspeed_ = msg->true_airspeed_m_s;
     });
 
+    std::cerr << vehicle_id_prefix + "/fmu/in/vehicle_command" << '\n';
+
   this->vehicle_rates_setpoint_pub_ =
     this->px4_node_->create_publisher<px4_msgs::msg::VehicleRatesSetpoint>(
-    "/fmu/in/vehicle_rates_setpoint", qos_profile);
+    vehicle_id_prefix + "/fmu/in/vehicle_rates_setpoint", qos_profile);
   this->vehicle_command_pub_ = this->px4_node_->create_publisher<px4_msgs::msg::VehicleCommand>(
-    "/fmu/in/vehicle_command", qos_profile);
+    vehicle_id_prefix + "/fmu/in/vehicle_command", qos_profile);
   this->vehicle_trajectory_setpoint_pub_ =
     this->px4_node_->create_publisher<px4_msgs::msg::TrajectorySetpoint>(
-    "/fmu/in/trajectory_setpoint", qos_profile);
+    vehicle_id_prefix + "/fmu/in/trajectory_setpoint", qos_profile);
   this->vehicle_offboard_control_mode_pub_ =
     this->px4_node_->create_publisher<px4_msgs::msg::OffboardControlMode>(
-    "/fmu/in/offboard_control_mode", qos_profile);
+    vehicle_id_prefix + "/fmu/in/offboard_control_mode", qos_profile);
 }
 
 VehicleGatewayPX4::~VehicleGatewayPX4()

--- a/vehicle_gateway_python/src/vehicle_gateway_python/vehicle_gateway.cpp
+++ b/vehicle_gateway_python/src/vehicle_gateway_python/vehicle_gateway.cpp
@@ -30,7 +30,8 @@ namespace vehicle_gateway_python
 {
 VehicleGatewayPython::VehicleGatewayPython(
   const std::vector<std::string> & _args,
-  const std::string & _plugin_name)
+  const std::string & _plugin_name,
+  unsigned int _vehicle_id)
 {
   this->loader_ = std::make_shared<pluginlib::ClassLoader<vehicle_gateway::VehicleGateway>>(
     "vehicle_gateway", "vehicle_gateway::VehicleGateway");
@@ -51,6 +52,7 @@ VehicleGatewayPython::VehicleGatewayPython(
     argv[index] = _args[index].c_str();
   }
 
+  this->gateway_->set_vehicle_id(_vehicle_id);
   this->gateway_->init(_args.size(), argv);
   delete[] argv;
 }
@@ -253,6 +255,11 @@ VehicleGatewayPython::~VehicleGatewayPython()
   this->Destroy();
 }
 
+unsigned int VehicleGatewayPython::GetVehicleID()
+{
+  return this->gateway_->get_vehicle_id();
+}
+
 void
 define_vehicle_gateway(py::object module)
 {
@@ -261,7 +268,7 @@ define_vehicle_gateway(py::object module)
     "VehicleGatewayPython")
   .def(
     py::init<const std::vector<std::string> &,
-    const std::string &>())
+    const std::string &, unsigned int>())
   .def(
     "destroy", &VehicleGatewayPython::Destroy,
     "Destroy object")
@@ -364,7 +371,10 @@ define_vehicle_gateway(py::object module)
     "Get altitude in meter")
   .def(
     "get_vtol_state", &VehicleGatewayPython::GetVtolState,
-    "Get VTOL state");
+    "Get VTOL state")
+  .def(
+    "get_vehicle_id", &VehicleGatewayPython::GetVehicleID,
+    "Get vehicleID");
 
   pybind11::enum_<vehicle_gateway::ARMING_STATE>(module, "ArmingState")
   .value("INIT", vehicle_gateway::ARMING_STATE::INIT)

--- a/vehicle_gateway_python/src/vehicle_gateway_python/vehicle_gateway.hpp
+++ b/vehicle_gateway_python/src/vehicle_gateway_python/vehicle_gateway.hpp
@@ -38,9 +38,13 @@ class VehicleGatewayPython : public Destroyable,
 public:
   VehicleGatewayPython(
     const std::vector<std::string> & _args,
-    const std::string & _plugin_name);
+    const std::string & _plugin_name,
+    unsigned int _vehicle_id);
 
   ~VehicleGatewayPython();
+
+  /// Get VehicleID
+  unsigned int GetVehicleID();
 
   /// Takeoff
   void Takeoff();

--- a/vehicle_gateway_python/vehicle_gateway/__init__.py
+++ b/vehicle_gateway_python/vehicle_gateway/__init__.py
@@ -29,6 +29,7 @@ VtolState = _vehicle_gateway.VtolState
 def init(
     args: Optional[List[str]] = None,
     plugin_type: str = None,
+    vehicle_id: int = 0,
 ) -> None:
     args if args is None else []
-    return _vehicle_gateway.VehicleGatewayPython(args, plugin_type)
+    return _vehicle_gateway.VehicleGatewayPython(args, plugin_type, vehicle_id)


### PR DESCRIPTION
Modify px4 topics to allow to use multirobot. I think the PR in PX4 is not required.

you can test this with `test_takeoff_land.py`. You should modify this line

```python
px4_gateway = vehicle_gateway.init(args=sys.argv, plugin_type='px4')
```

to

```python
px4_gateway = vehicle_gateway.init(args=sys.argv, plugin_type='px4', vehicle_id=1)
# or
# px4_gateway = vehicle_gateway.init(args=sys.argv, plugin_type='px4', vehicle_id=2)
```