### PR TITLE
ignore zenohc rosdep since it will be built from pure cmake package

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ git clone https://github.com/osrf/vehicle_gateway
 cd ~/vg
 vcs import src < src/vehicle_gateway/dependencies.repos
 source /opt/ros/humble/setup.bash
-rosdep update && rosdep install --from-paths src --ignore-src -y --skip-keys="gz-transport12 gz-common5 gz-math7 gz-msgs9 gz-gui7 gz-cmake3 gz-sim7"
+rosdep update && rosdep install --from-paths src --ignore-src -y --skip-keys="gz-transport12 gz-common5 gz-math7 gz-msgs9 gz-gui7 gz-cmake3 gz-sim7 zenohc"
 colcon build --event-handlers console_direct+
 ```
 


### PR DESCRIPTION
Although we clone `zenohc` as part of our `dependencies.yaml` repos list, it is a pure CMake package (i.e. without a `package.xml`) so rosdep doesn't recognize it and is thinks that it is missing when running `rosdep install`. We just need to add it to the ignore list of that command invocation so that it won't error out.