### PR TITLE
Add dependency for usleep

### DIFF
--- a/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
+++ b/vehicle_gateway_px4/src/vehicle_gateway_px4.cpp
@@ -20,6 +20,12 @@
 #include "px4_msgs/msg/vehicle_local_position_setpoint.hpp"
 #include "tf2/utils.h"
 
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <unistd.h>
+#endif
+
 namespace vehicle_gateway_px4
 {
 


### PR DESCRIPTION
I encountered this build warning when building a smaller set of packages. This should fix it. 