### PR TITLE
Fix `px4_msgs` causin colcon build to fail

### DIFF
--- a/Docker/dev/Dockerfile
+++ b/Docker/dev/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get update && apt-get upgrade -q -y && \
 RUN rosdep init && \
   rosdep update && \
   cd /home/vehicle_gateway && \
-  rosdep install --from-paths ./ -i -y --rosdistro humble --ignore-src --skip-keys="gz-math7 gz-transport12 gz-msgs9 gz-sim7 gz-cmake3 gz-common5 gz-gui7 micro_ros_agent"
+  rosdep install --from-paths ./ -i -y --rosdistro humble --ignore-src --skip-keys="gz-transport12 gz-common5 gz-math7 gz-msgs9 gz-gui7 gz-cmake3 gz-sim7 zenohc gz-transport7 gz-plugin2"
 
 RUN cd /home/vehicle_gateway && . /opt/ros/humble/local_setup.sh && colcon build --merge-install --event-handlers console_direct+ --cmake-args -DBUILD_TESTING=0
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ git clone https://github.com/osrf/vehicle_gateway
 cd ~/vg
 vcs import src < src/vehicle_gateway/dependencies.repos
 source /opt/ros/humble/setup.bash
-rosdep update && rosdep install --from-paths src --ignore-src -y --skip-keys="gz-transport12 gz-common5 gz-math7 gz-msgs9 gz-gui7 gz-cmake3 gz-sim7 zenohc"
+rosdep update && rosdep install --from-paths src --ignore-src -y --skip-keys="gz-transport12 gz-common5 gz-math7 gz-msgs9 gz-gui7 gz-cmake3 gz-sim7 zenohc gz-transport7 gz-plugin2"
+sudo apt install python3-colcon-common-extensions
 colcon build --event-handlers console_direct+
 ```
 

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -14,7 +14,7 @@ repositories:
   px4_msgs:
     type: git
     url: https://github.com/PX4/px4_msgs
-    version: main
+    version: "release/1.14"
   msp:
     type: git
     url: https://github.com/christianrauch/msp


### PR DESCRIPTION
As described in #127 the `colcon` build fails due to mismatching messages types between `vehicle_gateway_multi` and `px4_msgs`. Also the `rosdep` command in the `README.md` was causing issues, as detailed in #126 .