### PR TITLE
Pinned betaflight-firmware to 4.5

### DIFF
--- a/betaflight_sim/CMakeLists.txt
+++ b/betaflight_sim/CMakeLists.txt
@@ -15,7 +15,7 @@ externalproject_add(betaflight-firmware
   GIT_REPOSITORY
     https://github.com/betaflight/betaflight
   GIT_TAG
-    master
+    4.5-maintenance
   INSTALL_COMMAND
     mkdir -p ${CMAKE_INSTALL_PREFIX}/share/betaflight_sim/bin/ &&
     cp ./obj/main/betaflight_SITL.elf ${CMAKE_INSTALL_PREFIX}/share/betaflight_sim/bin/


### PR DESCRIPTION
Betaflight versions on the `main` branch require the package `gcc-arm-none-abi` version 13.2.1, which is not available in the repos of Ubuntu 22.04. Since Gazebo Garden is targeted and this version of Ubuntu is used I suggest to pin the branch of `betaflight-firmware` installed by `betaflight-sim` to `4.5-maintenance`.